### PR TITLE
🔒 Add missing security headers to API endpoint

### DIFF
--- a/api.php
+++ b/api.php
@@ -144,6 +144,11 @@ if ($requestOrigin !== '') {
         }
     }
 }
+header('X-Content-Type-Options: nosniff');
+header('X-Frame-Options: DENY');
+header('Content-Security-Policy: default-src \'none\'; frame-ancestors \'none\'');
+header('Strict-Transport-Security: max-age=31536000; includeSubDomains');
+header('Referrer-Policy: strict-origin-when-cross-origin');
 header('Access-Control-Allow-Methods: GET, POST, PUT, PATCH, OPTIONS');
 header('Access-Control-Allow-Headers: Content-Type, Authorization, X-CSRF-Token');
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {


### PR DESCRIPTION
This PR addresses a security vulnerability by adding essential security headers to `api.php`.

**What:**
- Added `X-Content-Type-Options: nosniff` to prevent MIME type sniffing.
- Added `X-Frame-Options: DENY` to prevent clickjacking.
- Added `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'` to restrict resource loading (appropriate for an API).
- Added `Strict-Transport-Security` (HSTS) to enforce HTTPS.
- Added `Referrer-Policy: strict-origin-when-cross-origin` to control referrer information.

**Risk:**
Without these headers, the application is more susceptible to cross-site scripting (XSS), clickjacking, and other web-based attacks.

**Solution:**
These headers are now set unconditionally in `api.php`, ensuring all responses are protected.

**Verification:**
- Verified headers using `curl -I`.
- Ran full regression test suite (`npm test`) with 48 passing tests.

---
*PR created automatically by Jules for task [5322604634519575070](https://jules.google.com/task/5322604634519575070) started by @erosero558558*