### PR TITLE
🧪 Add tests for get_service_price_amount in api-lib.php

### DIFF
--- a/tests/test-api-lib.php
+++ b/tests/test-api-lib.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Test script for api-lib.php
+ */
+
+require_once dirname(__DIR__) . '/api-lib.php';
+
+$passed = 0;
+$failed = 0;
+
+function assert_equals($expected, $actual, $message) {
+    global $passed, $failed;
+    if ($expected === $actual) {
+        echo "PASS: $message\n";
+        $passed++;
+    } else {
+        echo "FAIL: $message. Expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n";
+        $failed++;
+    }
+}
+
+echo "Testing get_service_price_amount()...\n";
+
+assert_equals(40.0, get_service_price_amount('consulta'), 'Price for consulta');
+assert_equals(25.0, get_service_price_amount('telefono'), 'Price for telefono');
+assert_equals(30.0, get_service_price_amount('video'), 'Price for video');
+assert_equals(150.0, get_service_price_amount('laser'), 'Price for laser');
+assert_equals(120.0, get_service_price_amount('rejuvenecimiento'), 'Price for rejuvenecimiento');
+assert_equals(0.0, get_service_price_amount('unknown'), 'Price for unknown service');
+assert_equals(0.0, get_service_price_amount(''), 'Price for empty service');
+
+echo "\nResults: $passed passed, $failed failed.\n";
+
+if ($failed > 0) {
+    exit(1);
+}


### PR DESCRIPTION
🎯 **What:**
Added a standalone PHP test script `tests/test-api-lib.php` to test the `get_service_price_amount` function in `api-lib.php`.

📊 **Coverage:**
The test covers:
- Valid services: 'consulta', 'telefono', 'video', 'laser', 'rejuvenecimiento'.
- Invalid services: 'unknown' (returns 0.0).
- Empty string: '' (returns 0.0).

✨ **Result:**
Verified that `get_service_price_amount` returns the correct float values for all defined services and handles invalid inputs gracefully by returning 0.0. The test script can be executed with `php tests/test-api-lib.php` and exits with code 0 on success and 1 on failure.

---
*PR created automatically by Jules for task [11762171644839834514](https://jules.google.com/task/11762171644839834514) started by @erosero558558*