### PR TITLE
Add unit tests for validate_email function

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
-    "test:ui": "npx playwright test --ui"
+    "test:ui": "npx playwright test --ui",
+    "test:php": "php tests/test_validate_email.php"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0"

--- a/tests/test_validate_email.php
+++ b/tests/test_validate_email.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../api-lib.php';
+
+$tests = [
+    // Valid emails
+    ['email' => 'test@example.com', 'expected' => true, 'desc' => 'Standard email'],
+    ['email' => 'user.name@domain.co.uk', 'expected' => true, 'desc' => 'Email with subdomains'],
+    ['email' => 'user+tag@example.com', 'expected' => true, 'desc' => 'Email with plus tag'],
+    ['email' => '123@example.com', 'expected' => true, 'desc' => 'Numeric local part'],
+
+    // Invalid emails
+    ['email' => '', 'expected' => false, 'desc' => 'Empty string'],
+    ['email' => 'plainaddress', 'expected' => false, 'desc' => 'Missing @ and domain'],
+    ['email' => '@example.com', 'expected' => false, 'desc' => 'Missing local part'],
+    ['email' => 'user@', 'expected' => false, 'desc' => 'Missing domain'],
+    ['email' => 'user@.com', 'expected' => false, 'desc' => 'Domain starts with dot'],
+    // Note: 'user@com' (no dot in domain) is considered invalid by filter_var in this environment
+    ['email' => 'user@com', 'expected' => false, 'desc' => 'Missing TLD / dot in domain'],
+    ['email' => 'user name@example.com', 'expected' => false, 'desc' => 'Spaces in email'],
+    ['email' => 'user@example .com', 'expected' => false, 'desc' => 'Spaces in domain'],
+];
+
+$failed = 0;
+$passed = 0;
+
+echo "Running validate_email tests...\n";
+
+foreach ($tests as $test) {
+    $result = validate_email($test['email']);
+    if ($result === $test['expected']) {
+        $passed++;
+    } else {
+        echo "FAIL: {$test['desc']} ({$test['email']}) - Expected " . ($test['expected'] ? 'true' : 'false') . ", got " . ($result ? 'true' : 'false') . "\n";
+        $failed++;
+    }
+}
+
+echo "\nSummary: $passed passed, $failed failed.\n";
+
+if ($failed > 0) {
+    exit(1);
+}
+
+exit(0);


### PR DESCRIPTION
This PR adds a comprehensive test suite for the `validate_email` function in `api-lib.php`. It introduces a new standalone PHP test file `tests/test_validate_email.php` and integrates it into the project's workflow via a new `npm run test:php` script.

### Changes
- Created `tests/test_validate_email.php`:
  - Validates standard emails, subdomains, and numeric local parts.
  - Validates invalid cases like empty strings, missing parts, and spaces.
- Updated `package.json`:
  - Added `"test:php": "php tests/test_validate_email.php"` to `scripts`.

### Verification
- Ran `npm run test:php` and confirmed all 12 test cases pass.
- Verified failure by temporarily breaking `validate_email` implementation.

---
*PR created automatically by Jules for task [15420584367336433553](https://jules.google.com/task/15420584367336433553) started by @erosero558558*