### PR TITLE
🧪 Add unit tests for payment_currency function

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "test": "npx playwright test",
+    "test:php": "php tests/test_payment_currency.php",
     "test:headed": "npx playwright test --headed",
     "test:ui": "npx playwright test --ui"
   },

--- a/tests/test_payment_currency.php
+++ b/tests/test_payment_currency.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../payment-lib.php';
+
+$tests = [];
+$passed = 0;
+$failed = 0;
+
+function run_test($name, $callback) {
+    global $tests, $passed, $failed;
+    try {
+        $callback();
+        echo "✅ PASS: $name\n";
+        $passed++;
+    } catch (Throwable $e) {
+        echo "❌ FAIL: $name - " . $e->getMessage() . "\n";
+        $failed++;
+    }
+}
+
+function assert_equals($expected, $actual) {
+    if ($expected !== $actual) {
+        throw new Exception("Expected '$expected', got '$actual'");
+    }
+}
+
+// Save original env
+$originalEnv = getenv('PIELARMONIA_PAYMENT_CURRENCY');
+
+// Test 1: Default
+run_test('Default currency is USD', function() {
+    putenv('PIELARMONIA_PAYMENT_CURRENCY'); // Unset
+    assert_equals('USD', payment_currency());
+});
+
+// Test 2: Valid EUR
+run_test('Valid currency EUR', function() {
+    putenv('PIELARMONIA_PAYMENT_CURRENCY=EUR');
+    assert_equals('EUR', payment_currency());
+});
+
+// Test 3: Lowercase conversion
+run_test('Lowercase currency converted to uppercase', function() {
+    putenv('PIELARMONIA_PAYMENT_CURRENCY=eur');
+    assert_equals('EUR', payment_currency());
+});
+
+// Test 4: Invalid format
+run_test('Invalid format returns USD', function() {
+    putenv('PIELARMONIA_PAYMENT_CURRENCY=EURO');
+    assert_equals('USD', payment_currency());
+});
+
+// Test 5: Whitespace trimming
+run_test('Whitespace is trimmed', function() {
+    putenv('PIELARMONIA_PAYMENT_CURRENCY= GBP ');
+    assert_equals('GBP', payment_currency());
+});
+
+// Restore original env
+if ($originalEnv !== false) {
+    putenv("PIELARMONIA_PAYMENT_CURRENCY=$originalEnv");
+} else {
+    putenv('PIELARMONIA_PAYMENT_CURRENCY');
+}
+
+echo "\nSummary: $passed passed, $failed failed.\n";
+if ($failed > 0) {
+    exit(1);
+}


### PR DESCRIPTION
Improved testing coverage for `payment-lib.php` by adding a standalone PHP unit test for the `payment_currency` function. This ensures that the function correctly handles environment variables, defaults, and validation.

**Changes:**
- Added `tests/test_payment_currency.php`: A PHP script that tests various scenarios for `payment_currency`.
- Updated `package.json`: Added `test:php` script to run the new test.

**Verification:**
- Ran `npm run test:php` and verified all 5 tests passed.
- Ran `npm test` (Playwright) to ensure no regressions in existing tests.

---
*PR created automatically by Jules for task [3156569208285958461](https://jules.google.com/task/3156569208285958461) started by @erosero558558*