### PR TITLE
🧹 Centralize rate limit configurations

### DIFF
--- a/admin-auth.php
+++ b/admin-auth.php
@@ -57,7 +57,7 @@ if ($method === 'GET' && $action === 'status') {
 }
 
 if ($method === 'POST' && $action === 'login') {
-    require_rate_limit('admin-login', 5, 300);
+    require_rate_limit('admin-login');
 
     $payload = require_json_body();
     $password = isset($payload['password']) ? (string) $payload['password'] : '';

--- a/api-lib.php
+++ b/api-lib.php
@@ -22,6 +22,20 @@ const ADMIN_PASSWORD_HASH_ENV = 'PIELARMONIA_ADMIN_PASSWORD_HASH';
 const APP_TIMEZONE = 'America/Guayaquil';
 const SESSION_TIMEOUT = 1800; // 30 minutos de inactividad
 
+const RATE_LIMIT_CONFIG = [
+    'admin-login' => [5, 300],
+    'figo-chat' => [15, 60],
+    'payment-intent' => [8, 60],
+    'payment-verify' => [12, 60],
+    'transfer-proof' => [6, 60],
+    'appointments' => [5, 60],
+    'callbacks' => [5, 60],
+    'reviews' => [3, 60],
+    'reschedule' => [5, 60],
+    'figo-backend' => [30, 60],
+    'default' => [10, 60]
+];
+
 date_default_timezone_set(APP_TIMEZONE);
 
 function local_date(string $format): string
@@ -764,8 +778,14 @@ function check_rate_limit(string $action, int $maxRequests = 10, int $windowSeco
     return true;
 }
 
-function require_rate_limit(string $action, int $maxRequests = 10, int $windowSeconds = 60): void
+function require_rate_limit(string $action, ?int $maxRequests = null, ?int $windowSeconds = null): void
 {
+    if ($maxRequests === null || $windowSeconds === null) {
+        $config = RATE_LIMIT_CONFIG[$action] ?? RATE_LIMIT_CONFIG['default'];
+        $maxRequests = $maxRequests ?? $config[0];
+        $windowSeconds = $windowSeconds ?? $config[1];
+    }
+
     if (!check_rate_limit($action, $maxRequests, $windowSeconds)) {
         json_response([
             'ok' => false,

--- a/api.php
+++ b/api.php
@@ -347,7 +347,7 @@ if ($method === 'GET' && $resource === 'payment-config') {
 }
 
 if ($method === 'POST' && $resource === 'payment-intent') {
-    require_rate_limit('payment-intent', 8, 60);
+    require_rate_limit('payment-intent');
 
     if (!payment_gateway_enabled()) {
         json_response([
@@ -438,7 +438,7 @@ if ($method === 'POST' && $resource === 'payment-intent') {
 }
 
 if ($method === 'POST' && $resource === 'payment-verify') {
-    require_rate_limit('payment-verify', 12, 60);
+    require_rate_limit('payment-verify');
 
     if (!payment_gateway_enabled()) {
         json_response([
@@ -480,7 +480,7 @@ if ($method === 'POST' && $resource === 'payment-verify') {
 }
 
 if ($method === 'POST' && $resource === 'transfer-proof') {
-    require_rate_limit('transfer-proof', 6, 60);
+    require_rate_limit('transfer-proof');
 
     if (!isset($_FILES['proof']) || !is_array($_FILES['proof'])) {
         json_response([
@@ -591,7 +591,7 @@ if ($method === 'POST' && $resource === 'stripe-webhook') {
 }
 
 if ($method === 'POST' && $resource === 'appointments') {
-    require_rate_limit('appointments', 5, 60);
+    require_rate_limit('appointments');
     $payload = require_json_body();
     $appointment = normalize_appointment($payload);
 
@@ -895,7 +895,7 @@ if (($method === 'PATCH' || $method === 'PUT') && $resource === 'appointments') 
 }
 
 if ($method === 'POST' && $resource === 'callbacks') {
-    require_rate_limit('callbacks', 5, 60);
+    require_rate_limit('callbacks');
     $payload = require_json_body();
     $callback = normalize_callback($payload);
 
@@ -955,7 +955,7 @@ if (($method === 'PATCH' || $method === 'PUT') && $resource === 'callbacks') {
 }
 
 if ($method === 'POST' && $resource === 'reviews') {
-    require_rate_limit('reviews', 3, 60);
+    require_rate_limit('reviews');
     $payload = require_json_body();
     $review = normalize_review($payload);
     if ($review['name'] === '' || $review['text'] === '') {
@@ -1035,7 +1035,7 @@ if ($method === 'GET' && $resource === 'reschedule') {
 }
 
 if ($method === 'PATCH' && $resource === 'reschedule') {
-    require_rate_limit('reschedule', 5, 60);
+    require_rate_limit('reschedule');
     $payload = require_json_body();
     $token = trim((string) ($payload['token'] ?? ''));
     $newDate = trim((string) ($payload['date'] ?? ''));

--- a/figo-backend.php
+++ b/figo-backend.php
@@ -516,7 +516,7 @@ if ($method !== 'POST') {
     ], 405);
 }
 
-require_rate_limit('figo-backend', 30, 60);
+require_rate_limit('figo-backend');
 $payload = require_json_body();
 
 if (figo_backend_is_telegram_update($payload)) {

--- a/figo-chat.php
+++ b/figo-chat.php
@@ -423,7 +423,7 @@ if ($method !== 'POST') {
 }
 
 start_secure_session();
-require_rate_limit('figo-chat', 15, 60);
+require_rate_limit('figo-chat');
 
 $payload = require_json_body();
 $messages = isset($payload['messages']) && is_array($payload['messages'])


### PR DESCRIPTION
🎯 **What:**
Centralized hardcoded rate limit values into a single `RATE_LIMIT_CONFIG` constant in `api-lib.php`. Refactored `require_rate_limit` to use this configuration. Updated call sites in `admin-auth.php`, `api.php`, `figo-chat.php`, and `figo-backend.php` to use the centralized logic.

💡 **Why:**
This improves maintainability by gathering all rate limit settings in one place, making it easier to tune and manage them without modifying multiple files. It also ensures consistency across the application.

✅ **Verification:**
- Ran `php -l` on all modified files to ensure no syntax errors.
- Ran `npm test` (Playwright) which passed all 48 tests, verifying no regressions in application functionality.
- Verified that `require_rate_limit` maintains backward compatibility for optional arguments but prioritizes configuration when arguments are omitted.

✨ **Result:**
Codebase is cleaner and rate limits are now centrally managed. Functionality remains unchanged.

---
*PR created automatically by Jules for task [13927087110105936327](https://jules.google.com/task/13927087110105936327) started by @erosero558558*