### PR TITLE
Add Cloudflare Turnstile CAPTCHA to booking form

### DIFF
--- a/api-lib.php
+++ b/api-lib.php
@@ -322,6 +322,57 @@ function is_https_request(): bool
     return false;
 }
 
+function turnstile_site_key(): string
+{
+    $key = getenv('PIELARMONIA_TURNSTILE_SITE_KEY');
+    return is_string($key) ? trim($key) : '';
+}
+
+function turnstile_secret_key(): string
+{
+    $key = getenv('PIELARMONIA_TURNSTILE_SECRET_KEY');
+    return is_string($key) ? trim($key) : '';
+}
+
+function verify_turnstile_token(string $token): bool
+{
+    $secret = turnstile_secret_key();
+    if ($secret === '') {
+        return true; // Si no hay clave secreta, no se valida (modo desarrollo/inseguro)
+    }
+
+    if ($token === '') {
+        return false;
+    }
+
+    $url = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+    $data = [
+        'secret' => $secret,
+        'response' => $token,
+        'remoteip' => $_SERVER['REMOTE_ADDR'] ?? ''
+    ];
+
+    $options = [
+        'http' => [
+            'header'  => "Content-type: application/x-www-form-urlencoded\r\n",
+            'method'  => 'POST',
+            'content' => http_build_query($data),
+            'timeout' => 5
+        ]
+    ];
+
+    $context  = stream_context_create($options);
+    $result = @file_get_contents($url, false, $context);
+
+    if ($result === false) {
+        error_log('Piel en Armonía: fallo al conectar con Turnstile verification');
+        return false; // Fall-closed
+    }
+
+    $json = json_decode($result, true);
+    return isset($json['success']) && $json['success'] === true;
+}
+
 function start_secure_session(): void
 {
     if (session_status() === PHP_SESSION_ACTIVE) {

--- a/env.example.php
+++ b/env.example.php
@@ -24,6 +24,10 @@
 // ── Orígenes permitidos (CORS) ────────────────────────
 // putenv('PIELARMONIA_ALLOWED_ORIGIN=https://pielarmonia.com');
 
+// ── CAPTCHA (Turnstile) ──────────────────────────────
+// putenv('PIELARMONIA_TURNSTILE_SITE_KEY=0x4AAAAAAABcDeFgHiJkLmNo');
+// putenv('PIELARMONIA_TURNSTILE_SECRET_KEY=0x4AAAAAAABcDeFgHiJkLmNoPqRsTuVwXyZ');
+
 // ── Chatbot (Figo) ───────────────────────────────────
 // IMPORTANTE: no apuntar al propio /figo-chat.php (genera recursión).
 // Usa el endpoint HTTP real del backend de Clawbot/Figo.

--- a/script.js
+++ b/script.js
@@ -1028,10 +1028,11 @@ async function loadPaymentConfig() {
             enabled: payload.enabled === true,
             provider: payload.provider || 'stripe',
             publishableKey: payload.publishableKey || '',
-            currency: payload.currency || 'USD'
+            currency: payload.currency || 'USD',
+            turnstileSiteKey: payload.turnstileSiteKey || ''
         };
     } catch (error) {
-        paymentConfig = { enabled: false, provider: 'stripe', publishableKey: '', currency: 'USD' };
+        paymentConfig = { enabled: false, provider: 'stripe', publishableKey: '', currency: 'USD', turnstileSiteKey: '' };
     }
     paymentConfigLoaded = true;
     paymentConfigLoadedAt = now;
@@ -1648,7 +1649,8 @@ function getBookingUiDeps() {
         openPaymentModal,
         setCurrentAppointment: (appointment) => {
             currentAppointment = appointment;
-        }
+        },
+        loadPaymentConfig
     };
 }
 


### PR DESCRIPTION
Implemented Cloudflare Turnstile CAPTCHA on the public booking endpoint to prevent spam and abuse.

**Changes:**
1.  **Backend (`api-lib.php`, `api.php`):**
    *   Added helper functions to read Turnstile keys from environment.
    *   Added `verify_turnstile_token` function to validate tokens against Cloudflare API.
    *   Updated `POST /appointments` to verify the token if the secret key is set.
    *   Updated `GET /payment-config` to return the site key to the frontend.

2.  **Frontend (`booking-ui.js`, `script.js`):**
    *   Updated `script.js` to load the site key.
    *   Updated `booking-ui.js` to inject the Turnstile script and widget into the booking form if the site key is present.
    *   Included the `captchaToken` in the appointment submission payload.

3.  **Configuration (`env.example.php`):**
    *   Added placeholders for `PIELARMONIA_TURNSTILE_SITE_KEY` and `PIELARMONIA_TURNSTILE_SECRET_KEY`.

**Security Note:**
The implementation fails open (allows requests) if the secret key is not configured in the environment, ensuring backward compatibility and preventing breakage in environments where CAPTCHA is not yet set up. Once configured, it enforces validation.

---
*PR created automatically by Jules for task [6712387585409808577](https://jules.google.com/task/6712387585409808577) started by @erosero558558*