### PR TITLE
Refactor CORS logic into reusable function in api-lib.php

### DIFF
--- a/admin-auth.php
+++ b/admin-auth.php
@@ -3,41 +3,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/api-lib.php';
 
-$requestOrigin = isset($_SERVER['HTTP_ORIGIN']) ? trim((string) $_SERVER['HTTP_ORIGIN']) : '';
-$allowedOrigin = getenv('PIELARMONIA_ALLOWED_ORIGIN');
-$allowedList = [];
-if (is_string($allowedOrigin) && trim($allowedOrigin) !== '') {
-    foreach (explode(',', $allowedOrigin) as $origin) {
-        $origin = trim((string) $origin);
-        if ($origin !== '') {
-            $allowedList[] = rtrim($origin, '/');
-        }
-    }
-}
-
-$host = isset($_SERVER['HTTP_HOST']) ? trim((string) $_SERVER['HTTP_HOST']) : '';
-if ($host !== '') {
-    $allowedList[] = (is_https_request() ? 'https' : 'http') . '://' . $host;
-}
-
-$allowedList = array_values(array_unique(array_filter($allowedList)));
-if ($requestOrigin !== '') {
-    $normalizedOrigin = rtrim($requestOrigin, '/');
-    foreach ($allowedList as $origin) {
-        if (strcasecmp($normalizedOrigin, $origin) === 0) {
-            header('Access-Control-Allow-Origin: ' . $requestOrigin);
-            header('Access-Control-Allow-Credentials: true');
-            header('Vary: Origin');
-            break;
-        }
-    }
-}
-header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
-header('Access-Control-Allow-Headers: Content-Type, X-CSRF-Token');
-if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    http_response_code(204);
-    exit();
-}
+api_apply_cors(['GET', 'POST', 'OPTIONS'], ['Content-Type', 'X-CSRF-Token'], true);
 
 start_secure_session();
 

--- a/api.php
+++ b/api.php
@@ -115,41 +115,7 @@ function api_is_figo_recursive_config(string $endpoint): bool
     return $endpointPath === '/figo-chat.php';
 }
 
-$requestOrigin = isset($_SERVER['HTTP_ORIGIN']) ? trim((string) $_SERVER['HTTP_ORIGIN']) : '';
-$allowedOrigin = getenv('PIELARMONIA_ALLOWED_ORIGIN');
-$allowedList = [];
-if (is_string($allowedOrigin) && trim($allowedOrigin) !== '') {
-    foreach (explode(',', $allowedOrigin) as $origin) {
-        $origin = trim((string) $origin);
-        if ($origin !== '') {
-            $allowedList[] = rtrim($origin, '/');
-        }
-    }
-}
-
-$host = isset($_SERVER['HTTP_HOST']) ? trim((string) $_SERVER['HTTP_HOST']) : '';
-if ($host !== '') {
-    $allowedList[] = (is_https_request() ? 'https' : 'http') . '://' . $host;
-}
-
-$allowedList = array_values(array_unique(array_filter($allowedList)));
-if ($requestOrigin !== '') {
-    $normalizedOrigin = rtrim($requestOrigin, '/');
-    foreach ($allowedList as $origin) {
-        if (strcasecmp($normalizedOrigin, $origin) === 0) {
-            header('Access-Control-Allow-Origin: ' . $requestOrigin);
-            header('Access-Control-Allow-Credentials: true');
-            header('Vary: Origin');
-            break;
-        }
-    }
-}
-header('Access-Control-Allow-Methods: GET, POST, PUT, PATCH, OPTIONS');
-header('Access-Control-Allow-Headers: Content-Type, Authorization, X-CSRF-Token');
-if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    http_response_code(204);
-    exit();
-}
+api_apply_cors(['GET', 'POST', 'PUT', 'PATCH', 'OPTIONS'], ['Content-Type', 'Authorization', 'X-CSRF-Token'], true);
 
 $method = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');
 $resource = isset($_GET['resource']) ? (string) $_GET['resource'] : '';

--- a/figo-backend.php
+++ b/figo-backend.php
@@ -9,42 +9,6 @@ require_once __DIR__ . '/api-lib.php';
  * - Telegram webhook mode: receives Telegram updates and replies as bot
  */
 
-function figo_backend_apply_cors(): void
-{
-    header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
-    header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Telegram-Bot-Api-Secret-Token');
-    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
-
-    $origin = isset($_SERVER['HTTP_ORIGIN']) ? trim((string) $_SERVER['HTTP_ORIGIN']) : '';
-    if ($origin === '') {
-        return;
-    }
-
-    $allowed = [];
-    $rawAllowed = getenv('PIELARMONIA_ALLOWED_ORIGINS');
-    if (is_string($rawAllowed) && trim($rawAllowed) !== '') {
-        foreach (explode(',', $rawAllowed) as $item) {
-            $item = trim($item);
-            if ($item !== '') {
-                $allowed[] = rtrim($item, '/');
-            }
-        }
-    }
-
-    $allowed[] = 'https://pielarmonia.com';
-    $allowed[] = 'https://www.pielarmonia.com';
-    $allowed = array_values(array_unique(array_filter($allowed)));
-
-    $normalizedOrigin = rtrim($origin, '/');
-    foreach ($allowed as $allowedOrigin) {
-        if (strcasecmp($normalizedOrigin, $allowedOrigin) === 0) {
-            header('Access-Control-Allow-Origin: ' . $origin);
-            header('Vary: Origin');
-            return;
-        }
-    }
-}
-
 function figo_backend_normalize_text(string $text): string
 {
     $text = strtolower(trim($text));
@@ -478,13 +442,10 @@ function figo_backend_handle_telegram_update(array $update, string $telegramToke
     json_response(['ok' => true, 'handled' => true]);
 }
 
-figo_backend_apply_cors();
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+api_apply_cors(['GET', 'POST', 'OPTIONS'], ['Content-Type', 'Authorization', 'X-Telegram-Bot-Api-Secret-Token'], true);
 
 $method = strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? 'GET'));
-if ($method === 'OPTIONS') {
-    http_response_code(204);
-    exit();
-}
 
 header('Content-Type: application/json; charset=utf-8');
 


### PR DESCRIPTION
- Added `api_apply_cors` to `api-lib.php` to handle CORS headers centrally.
- Updated `admin-auth.php`, `api.php`, `figo-backend.php`, and `figo-chat.php` to use `api_apply_cors`.
- Removed duplicated and dead code related to CORS and OPTIONS handling in `figo-*.php`.
- Verified changes using a custom verification script to ensure headers are set correctly for allowed and disallowed origins.

---
*PR created automatically by Jules for task [8816267398768684170](https://jules.google.com/task/8816267398768684170) started by @erosero558558*