### PR TITLE
Improve Light Mode Color Palette

### DIFF
--- a/php_server.log
+++ b/php_server.log
@@ -1,3833 +1,3190 @@
-[Thu Feb 19 00:28:40 2026] PHP 8.3.6 Development Server (http://localhost:8000) started
-[Thu Feb 19 00:28:45 2026] [::1]:59734 Accepted
-[Thu Feb 19 00:28:45 2026] [::1]:59734 [200]: HEAD /api.php?resource=health
-[Thu Feb 19 00:28:45 2026] [::1]:59734 Closing
-[Thu Feb 19 00:28:56 2026] [::1]:54754 Accepted
-[Thu Feb 19 00:28:56 2026] [::1]:54754 [200]: GET /api.php?resource=health
-[Thu Feb 19 00:28:56 2026] [::1]:54754 Closing
-[Thu Feb 19 00:29:03 2026] [::1]:48984 Accepted
-[Thu Feb 19 00:29:03 2026] [::1]:48984 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:29:03 2026] [::1]:48984 Closing
-[Thu Feb 19 00:29:06 2026] [::1]:48994 Accepted
-[Thu Feb 19 00:29:06 2026] [::1]:48994 [200]: GET /figo-chat.php
-[Thu Feb 19 00:29:06 2026] [::1]:48994 Closing
-[Thu Feb 19 00:29:06 2026] [::1]:49004 Accepted
-[Thu Feb 19 00:29:06 2026] [::1]:49004 [404]: GET /data/ - No such file or directory
-[Thu Feb 19 00:29:06 2026] [::1]:49004 Closing
-[Thu Feb 19 00:29:42 2026] [::1]:57046 Accepted
-[Thu Feb 19 00:29:42 2026] [::1]:57046 [200]: GET /api.php?resource=health
-[Thu Feb 19 00:29:42 2026] [::1]:57046 Closing
-[Thu Feb 19 00:29:47 2026] [::1]:36378 Accepted
-[Thu Feb 19 00:29:47 2026] [::1]:36378 [200]: GET /admin.html
-[Thu Feb 19 00:29:47 2026] [::1]:36378 Closing
-[Thu Feb 19 00:29:47 2026] [::1]:36392 Accepted
-[Thu Feb 19 00:29:47 2026] [::1]:36398 Accepted
-[Thu Feb 19 00:29:47 2026] [::1]:36392 [200]: GET /styles.css
-[Thu Feb 19 00:29:47 2026] [::1]:36392 Closing
-[Thu Feb 19 00:29:47 2026] [::1]:36398 [200]: GET /admin.css
-[Thu Feb 19 00:29:47 2026] [::1]:36398 Closing
-[Thu Feb 19 00:29:47 2026] [::1]:36404 Accepted
-[Thu Feb 19 00:29:47 2026] [::1]:36404 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:29:47 2026] [::1]:36404 Closing
-[Thu Feb 19 00:29:48 2026] [::1]:36410 Accepted
-[Thu Feb 19 00:29:48 2026] [::1]:36410 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:29:48 2026] [::1]:36410 Closing
-[Thu Feb 19 00:29:48 2026] [::1]:36412 Accepted
-[Thu Feb 19 00:29:48 2026] [::1]:36412 [401]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:29:48 2026] [::1]:36412 Closing
-[Thu Feb 19 00:29:48 2026] [::1]:36414 Accepted
-[Thu Feb 19 00:29:48 2026] [::1]:36414 [200]: GET /admin.html
-[Thu Feb 19 00:29:48 2026] [::1]:36414 Closing
-[Thu Feb 19 00:29:48 2026] [::1]:36424 Accepted
-[Thu Feb 19 00:29:48 2026] [::1]:36436 Accepted
-[Thu Feb 19 00:29:48 2026] [::1]:36424 [200]: GET /styles.css
-[Thu Feb 19 00:29:48 2026] [::1]:36424 Closing
-[Thu Feb 19 00:29:48 2026] [::1]:36436 [200]: GET /admin.css
-[Thu Feb 19 00:29:48 2026] [::1]:36436 Closing
-[Thu Feb 19 00:29:48 2026] [::1]:36446 Accepted
-[Thu Feb 19 00:29:48 2026] [::1]:36446 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:29:48 2026] [::1]:36446 Closing
-[Thu Feb 19 00:29:48 2026] [::1]:36448 Accepted
-[Thu Feb 19 00:29:48 2026] [::1]:36448 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:29:48 2026] [::1]:36448 Closing
-[Thu Feb 19 00:29:49 2026] [::1]:36450 Accepted
-[Thu Feb 19 00:29:49 2026] [::1]:36450 [200]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:29:49 2026] [::1]:36450 Closing
-[Thu Feb 19 00:29:49 2026] [::1]:36458 Accepted
-[Thu Feb 19 00:29:49 2026] [::1]:36458 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:29:49 2026] [::1]:36458 Closing
-[Thu Feb 19 00:30:00 2026] [::1]:57436 Accepted
-[Thu Feb 19 00:30:00 2026] [::1]:57436 [200]: GET /index.html
-[Thu Feb 19 00:30:00 2026] [::1]:57436 Closing
-[Thu Feb 19 00:30:00 2026] [::1]:57438 Accepted
-[Thu Feb 19 00:30:00 2026] [::1]:57446 Accepted
-[Thu Feb 19 00:30:00 2026] [::1]:57462 Accepted
-[Thu Feb 19 00:30:00 2026] [::1]:57438 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:30:00 2026] [::1]:57438 Closing
-[Thu Feb 19 00:30:00 2026] [::1]:57446 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:30:00 2026] [::1]:57446 Closing
-[Thu Feb 19 00:30:00 2026] [::1]:57462 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:30:00 2026] [::1]:57462 Closing
-[Thu Feb 19 00:30:00 2026] [::1]:57478 Accepted
-[Thu Feb 19 00:30:00 2026] [::1]:57478 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:30:00 2026] [::1]:57478 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57484 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57494 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57500 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57514 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57484 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:30:01 2026] [::1]:57484 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57494 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:30:01 2026] [::1]:57494 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57500 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:30:01 2026] [::1]:57500 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57514 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:30:01 2026] [::1]:57514 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57520 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57536 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57520 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:30:01 2026] [::1]:57542 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57536 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:30:01 2026] [::1]:57542 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:30:01 2026] [::1]:57520 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57536 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57542 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57544 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57548 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57564 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57580 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57582 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57592 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57544 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:30:01 2026] [::1]:57544 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57548 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:30:01 2026] [::1]:57548 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57564 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:30:01 2026] [::1]:57564 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57580 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:30:01 2026] [::1]:57580 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57582 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:30:01 2026] [::1]:57582 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57592 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:30:01 2026] [::1]:57592 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57604 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57604 [200]: GET /index.html
-[Thu Feb 19 00:30:01 2026] [::1]:57604 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57620 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57624 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57636 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57620 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:30:01 2026] [::1]:57620 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57624 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:30:01 2026] [::1]:57636 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:30:01 2026] [::1]:57624 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57636 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57652 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57652 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:30:01 2026] [::1]:57652 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57666 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57674 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57678 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57684 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57666 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:30:01 2026] [::1]:57666 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57674 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:30:01 2026] [::1]:57674 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57678 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:30:01 2026] [::1]:57678 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57684 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:30:01 2026] [::1]:57684 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57694 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57694 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:30:01 2026] [::1]:57694 Closing
-[Thu Feb 19 00:30:01 2026] [::1]:57706 Accepted
-[Thu Feb 19 00:30:01 2026] [::1]:57706 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:30:01 2026] [::1]:57706 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57720 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57720 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:30:02 2026] [::1]:57720 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57736 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57746 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57762 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57776 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57780 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57736 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:30:02 2026] [::1]:57736 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57746 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:30:02 2026] [::1]:57746 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57762 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:30:02 2026] [::1]:57776 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:30:02 2026] [::1]:57780 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:30:02 2026] [::1]:57762 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57776 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57780 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57796 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57796 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:30:02 2026] [::1]:57796 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57806 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57806 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:30:02 2026] [::1]:57806 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57816 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57816 [200]: GET /api.php?resource=booked-slots&date=2026-02-21&doctor=rosero
-[Thu Feb 19 00:30:02 2026] [::1]:57816 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57826 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57836 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57844 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57850 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57856 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57862 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57826 [200]: GET /images/optimized/service-consulta.avif
-[Thu Feb 19 00:30:02 2026] [::1]:57826 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57836 [200]: GET /images/optimized/service-telemedicina.avif
-[Thu Feb 19 00:30:02 2026] [::1]:57836 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57844 [200]: GET /images/optimized/service-laser.avif
-[Thu Feb 19 00:30:02 2026] [::1]:57850 [200]: GET /images/optimized/service-rejuvenecimiento.avif
-[Thu Feb 19 00:30:02 2026] [::1]:57856 [200]: GET /images/optimized/service-acne.avif
-[Thu Feb 19 00:30:02 2026] [::1]:57862 [200]: GET /images/optimized/service-cancer.avif
-[Thu Feb 19 00:30:02 2026] [::1]:57844 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57850 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57856 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57862 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57868 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57882 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57868 [200]: GET /images/optimized/team-rosero.avif
-[Thu Feb 19 00:30:02 2026] [::1]:57868 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57882 [200]: GET /images/optimized/team-narvaez.avif
-[Thu Feb 19 00:30:02 2026] [::1]:57882 Closing
-[Thu Feb 19 00:30:02 2026] [::1]:57888 Accepted
-[Thu Feb 19 00:30:02 2026] [::1]:57888 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:30:02 2026] [::1]:57888 Closing
-[Thu Feb 19 00:30:03 2026] [::1]:57900 Accepted
-[Thu Feb 19 00:30:03 2026] [::1]:57900 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:30:03 2026] [::1]:57900 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57916 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57916 [200]: GET /index.html
-[Thu Feb 19 00:30:04 2026] [::1]:57916 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57918 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57920 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57922 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57918 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:30:04 2026] [::1]:57920 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:30:04 2026] [::1]:57922 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:30:04 2026] [::1]:57918 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57920 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57922 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57936 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57936 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:30:04 2026] [::1]:57936 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57942 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57944 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57942 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:30:04 2026] [::1]:57950 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57954 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57942 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57944 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:30:04 2026] [::1]:57950 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:30:04 2026] [::1]:57944 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57950 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57954 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:30:04 2026] [::1]:57954 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57962 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57966 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57974 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57988 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57994 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58008 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:57962 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:30:04 2026] [::1]:57962 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57966 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:30:04 2026] [::1]:57966 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57974 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:30:04 2026] [::1]:57974 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57988 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:30:04 2026] [::1]:57988 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:57994 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:30:04 2026] [::1]:57994 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58008 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:30:04 2026] [::1]:58008 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58024 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58030 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58046 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58024 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:30:04 2026] [::1]:58024 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58030 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:30:04 2026] [::1]:58046 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:30:04 2026] [::1]:58030 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58046 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58054 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58054 [200]: GET /index.html
-[Thu Feb 19 00:30:04 2026] [::1]:58054 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58056 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58072 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58074 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58056 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:30:04 2026] [::1]:58072 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:30:04 2026] [::1]:58074 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:30:04 2026] [::1]:58056 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58072 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58074 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58088 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58088 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:30:04 2026] [::1]:58088 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58094 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58094 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:30:04 2026] [::1]:58094 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58098 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58100 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58108 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58098 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:30:04 2026] [::1]:58100 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:30:04 2026] [::1]:58108 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:30:04 2026] [::1]:58098 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58100 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58108 Closing
-[Thu Feb 19 00:30:04 2026] [::1]:58114 Accepted
-[Thu Feb 19 00:30:04 2026] [::1]:58114 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:30:04 2026] [::1]:58114 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58126 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58132 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58126 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:30:05 2026] [::1]:58132 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:30:05 2026] [::1]:58126 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58132 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58144 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58158 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58160 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58168 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58180 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58184 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58144 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:30:05 2026] [::1]:58158 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:30:05 2026] [::1]:58160 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:30:05 2026] [::1]:58168 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:30:05 2026] [::1]:58180 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:30:05 2026] [::1]:58184 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:30:05 2026] [::1]:58144 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58158 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58160 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58168 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58180 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58184 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58194 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58194 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:30:05 2026] [::1]:58194 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58196 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58196 [200]: GET /figo-chat.php
-[Thu Feb 19 00:30:05 2026] [::1]:58196 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58212 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58212 [404]: GET /data/ - No such file or directory
-[Thu Feb 19 00:30:05 2026] [::1]:58212 Closing
-[Thu Feb 19 00:30:05 2026] [::1]:58228 Accepted
-[Thu Feb 19 00:30:05 2026] [::1]:58228 [404]: GET /uploads/ - No such file or directory
-[Thu Feb 19 00:30:05 2026] [::1]:58228 Closing
-[Thu Feb 19 00:30:40 2026] [::1]:38666 Accepted
-[Thu Feb 19 00:30:40 2026] [::1]:38666 [200]: GET /test_env.php
-[Thu Feb 19 00:30:40 2026] [::1]:38666 Closing
-[Thu Feb 19 00:30:51 2026] [::1]:53082 Accepted
-[Thu Feb 19 00:30:51 2026] [::1]:53082 [200]: GET /test_env.php?show_hash=1
-[Thu Feb 19 00:30:51 2026] [::1]:53082 Closing
-[Thu Feb 19 00:31:04 2026] [::1]:37384 Accepted
-[Thu Feb 19 00:31:04 2026] [::1]:37384 [200]: GET /test_env.php
-[Thu Feb 19 00:31:04 2026] [::1]:37384 Closing
-[Thu Feb 19 00:31:37 2026] [::1]:55700 Accepted
-[Thu Feb 19 00:31:37 2026] [::1]:55700 [200]: GET /api.php?resource=health
-[Thu Feb 19 00:31:37 2026] [::1]:55700 Closing
-[Thu Feb 19 00:31:38 2026] [::1]:55716 Accepted
-[Thu Feb 19 00:31:38 2026] [::1]:55716 [200]: GET /admin.html
-[Thu Feb 19 00:31:38 2026] [::1]:55716 Closing
-[Thu Feb 19 00:31:38 2026] [::1]:55730 Accepted
-[Thu Feb 19 00:31:38 2026] [::1]:55734 Accepted
-[Thu Feb 19 00:31:38 2026] [::1]:55730 [200]: GET /styles.css
-[Thu Feb 19 00:31:38 2026] [::1]:55730 Closing
-[Thu Feb 19 00:31:38 2026] [::1]:55734 [200]: GET /admin.css
-[Thu Feb 19 00:31:38 2026] [::1]:55734 Closing
-[Thu Feb 19 00:31:38 2026] [::1]:55748 Accepted
-[Thu Feb 19 00:31:38 2026] [::1]:55748 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:31:38 2026] [::1]:55748 Closing
-[Thu Feb 19 00:31:38 2026] [::1]:55760 Accepted
-[Thu Feb 19 00:31:38 2026] [::1]:55760 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:31:38 2026] [::1]:55760 Closing
-[Thu Feb 19 00:31:38 2026] [::1]:55768 Accepted
-[Thu Feb 19 00:31:38 2026] DEBUG: password received: 'incorrecta'
-[Thu Feb 19 00:31:38 2026] DEBUG: admin password env: 'admin123'
-[Thu Feb 19 00:31:38 2026] DEBUG: admin password hash env: ''
-[Thu Feb 19 00:31:38 2026] DEBUG: Login failed for password: 'incorrecta'
-[Thu Feb 19 00:31:38 2026] [::1]:55768 [401]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:31:38 2026] [::1]:55768 Closing
-[Thu Feb 19 00:31:38 2026] [::1]:55784 Accepted
-[Thu Feb 19 00:31:38 2026] [::1]:55784 [200]: GET /admin.html
-[Thu Feb 19 00:31:38 2026] [::1]:55784 Closing
-[Thu Feb 19 00:31:38 2026] [::1]:55788 Accepted
-[Thu Feb 19 00:31:38 2026] [::1]:55796 Accepted
-[Thu Feb 19 00:31:38 2026] [::1]:55788 [200]: GET /styles.css
-[Thu Feb 19 00:31:38 2026] [::1]:55788 Closing
-[Thu Feb 19 00:31:38 2026] [::1]:55796 [200]: GET /admin.css
-[Thu Feb 19 00:31:38 2026] [::1]:55796 Closing
-[Thu Feb 19 00:31:38 2026] [::1]:55800 Accepted
-[Thu Feb 19 00:31:38 2026] [::1]:55800 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:31:38 2026] [::1]:55800 Closing
-[Thu Feb 19 00:31:38 2026] [::1]:55806 Accepted
-[Thu Feb 19 00:31:38 2026] [::1]:55806 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:31:38 2026] [::1]:55806 Closing
-[Thu Feb 19 00:31:39 2026] [::1]:55818 Accepted
-[Thu Feb 19 00:31:39 2026] DEBUG: password received: 'admin123'
-[Thu Feb 19 00:31:39 2026] DEBUG: admin password env: 'admin123'
-[Thu Feb 19 00:31:39 2026] DEBUG: admin password hash env: ''
-[Thu Feb 19 00:31:39 2026] [::1]:55818 [200]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:31:39 2026] [::1]:55818 Closing
-[Thu Feb 19 00:31:39 2026] [::1]:55828 Accepted
-[Thu Feb 19 00:31:39 2026] [::1]:55828 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:31:39 2026] [::1]:55828 Closing
-[Thu Feb 19 00:31:50 2026] [::1]:36490 Accepted
-[Thu Feb 19 00:31:50 2026] [::1]:36490 [200]: GET /index.html
-[Thu Feb 19 00:31:50 2026] [::1]:36490 Closing
-[Thu Feb 19 00:31:50 2026] [::1]:36506 Accepted
-[Thu Feb 19 00:31:50 2026] [::1]:36508 Accepted
-[Thu Feb 19 00:31:50 2026] [::1]:36506 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:31:50 2026] [::1]:36508 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:31:50 2026] [::1]:36506 Closing
-[Thu Feb 19 00:31:50 2026] [::1]:36508 Closing
-[Thu Feb 19 00:31:50 2026] [::1]:36510 Accepted
-[Thu Feb 19 00:31:50 2026] [::1]:36510 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:31:50 2026] [::1]:36510 Closing
-[Thu Feb 19 00:31:50 2026] [::1]:36516 Accepted
-[Thu Feb 19 00:31:50 2026] [::1]:36516 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:31:50 2026] [::1]:36516 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36532 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36536 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36538 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36544 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36532 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:31:51 2026] [::1]:36532 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36536 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:31:51 2026] [::1]:36536 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36538 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:31:51 2026] [::1]:36544 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:31:51 2026] [::1]:36538 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36544 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36560 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36560 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:31:51 2026] [::1]:36560 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36566 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36566 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:31:51 2026] [::1]:36566 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36570 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36570 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:31:51 2026] [::1]:36570 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36572 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36578 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36584 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36588 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36598 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36572 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:31:51 2026] [::1]:36572 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36578 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:31:51 2026] [::1]:36578 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36584 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:31:51 2026] [::1]:36584 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36588 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:31:51 2026] [::1]:36588 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36606 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36598 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:31:51 2026] [::1]:36598 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36606 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:31:51 2026] [::1]:36606 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36622 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36622 [200]: GET /index.html
-[Thu Feb 19 00:31:51 2026] [::1]:36622 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36626 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36628 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36638 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36626 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:31:51 2026] [::1]:36628 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:31:51 2026] [::1]:36638 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:31:51 2026] [::1]:36626 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36628 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36638 Closing
-[Thu Feb 19 00:31:51 2026] [::1]:36646 Accepted
-[Thu Feb 19 00:31:51 2026] [::1]:36646 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:31:51 2026] [::1]:36646 Closing
-[Thu Feb 19 00:31:52 2026] [::1]:36656 Accepted
-[Thu Feb 19 00:31:52 2026] [::1]:36672 Accepted
-[Thu Feb 19 00:31:52 2026] [::1]:36684 Accepted
-[Thu Feb 19 00:31:52 2026] [::1]:36700 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36656 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36656 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36672 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36684 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36700 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36672 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36684 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36700 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36712 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36712 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:31:53 2026] [::1]:36712 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36720 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36720 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:31:53 2026] [::1]:36720 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36726 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36726 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:31:53 2026] [::1]:36726 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36740 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36740 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:31:53 2026] [::1]:36740 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36752 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36758 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36772 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36784 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36752 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:31:53 2026] [::1]:36758 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:31:53 2026] [::1]:36772 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:31:53 2026] [::1]:36788 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36784 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:31:53 2026] [::1]:36788 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:31:53 2026] [::1]:36752 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36758 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36772 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36784 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36788 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36804 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36804 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:31:53 2026] [::1]:36804 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36810 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36810 [200]: GET /api.php?resource=booked-slots&date=2026-02-21&doctor=rosero
-[Thu Feb 19 00:31:53 2026] [::1]:36810 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36818 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36826 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36832 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36836 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36846 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36852 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36818 [200]: GET /images/optimized/service-consulta.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36826 [200]: GET /images/optimized/service-telemedicina.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36832 [200]: GET /images/optimized/service-laser.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36836 [200]: GET /images/optimized/service-rejuvenecimiento.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36846 [200]: GET /images/optimized/service-acne.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36852 [200]: GET /images/optimized/service-cancer.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36818 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36826 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36832 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36836 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36846 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36852 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36864 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36870 Accepted
-[Thu Feb 19 00:31:53 2026] [::1]:36864 [200]: GET /images/optimized/team-rosero.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36864 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36870 [200]: GET /images/optimized/team-narvaez.avif
-[Thu Feb 19 00:31:53 2026] [::1]:36870 Closing
-[Thu Feb 19 00:31:53 2026] [::1]:36882 Accepted
-[Thu Feb 19 00:31:54 2026] [::1]:36882 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:31:54 2026] [::1]:36882 Closing
-[Thu Feb 19 00:31:55 2026] [::1]:36890 Accepted
-[Thu Feb 19 00:31:55 2026] [::1]:36890 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:31:55 2026] [::1]:36890 Closing
-[Thu Feb 19 00:31:55 2026] [::1]:36902 Accepted
-[Thu Feb 19 00:31:55 2026] [::1]:36902 [200]: GET /index.html
-[Thu Feb 19 00:31:55 2026] [::1]:36902 Closing
-[Thu Feb 19 00:31:55 2026] [::1]:36910 Accepted
-[Thu Feb 19 00:31:55 2026] [::1]:36914 Accepted
-[Thu Feb 19 00:31:55 2026] [::1]:36930 Accepted
-[Thu Feb 19 00:31:55 2026] [::1]:36910 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:31:55 2026] [::1]:36910 Closing
-[Thu Feb 19 00:31:55 2026] [::1]:36914 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:31:55 2026] [::1]:36930 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:31:55 2026] [::1]:36914 Closing
-[Thu Feb 19 00:31:55 2026] [::1]:36930 Closing
-[Thu Feb 19 00:31:55 2026] [::1]:36938 Accepted
-[Thu Feb 19 00:31:55 2026] [::1]:36938 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:31:55 2026] [::1]:36938 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:36950 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:36956 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:36966 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:36978 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:36950 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:31:56 2026] [::1]:36956 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:31:56 2026] [::1]:36966 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:31:56 2026] [::1]:36978 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:31:56 2026] [::1]:36950 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:36956 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:36966 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:36978 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:36994 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37000 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37008 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37016 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37028 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37032 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:36994 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:31:56 2026] [::1]:36994 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37000 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:31:56 2026] [::1]:37000 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37008 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:31:56 2026] [::1]:37008 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37016 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:31:56 2026] [::1]:37016 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37028 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:31:56 2026] [::1]:37028 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37032 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:31:56 2026] [::1]:37032 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37036 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37050 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37060 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37036 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:31:56 2026] [::1]:37036 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37050 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:31:56 2026] [::1]:37050 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37060 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:31:56 2026] [::1]:37060 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37072 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37072 [200]: GET /index.html
-[Thu Feb 19 00:31:56 2026] [::1]:37072 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37080 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37092 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37080 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:31:56 2026] [::1]:37106 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37092 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:31:56 2026] [::1]:37106 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:31:56 2026] [::1]:37080 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37092 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37106 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37112 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37112 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:31:56 2026] [::1]:37112 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37116 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37130 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37146 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37160 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37116 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:31:56 2026] [::1]:37130 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:31:56 2026] [::1]:37146 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:31:56 2026] [::1]:37160 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:31:56 2026] [::1]:37116 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37130 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37146 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37160 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37166 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37166 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:31:56 2026] [::1]:37166 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37180 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37196 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37180 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:31:56 2026] [::1]:37202 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37196 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:31:56 2026] [::1]:37212 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37202 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:31:56 2026] [::1]:37180 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37212 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:31:56 2026] [::1]:37196 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37202 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37212 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37214 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37226 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37214 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:31:56 2026] [::1]:37236 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37226 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:31:56 2026] [::1]:37238 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37236 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:31:56 2026] [::1]:37214 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37238 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:31:56 2026] [::1]:37226 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37236 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37238 Closing
-[Thu Feb 19 00:31:56 2026] [::1]:37248 Accepted
-[Thu Feb 19 00:31:56 2026] [::1]:37248 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:31:56 2026] [::1]:37248 Closing
-[Thu Feb 19 00:31:57 2026] [::1]:48026 Accepted
-[Thu Feb 19 00:31:57 2026] [::1]:48026 [200]: GET /figo-chat.php
-[Thu Feb 19 00:31:57 2026] [::1]:48026 Closing
-[Thu Feb 19 00:31:57 2026] [::1]:48034 Accepted
-[Thu Feb 19 00:31:57 2026] [::1]:48034 [404]: GET /data/ - No such file or directory
-[Thu Feb 19 00:31:57 2026] [::1]:48034 Closing
-[Thu Feb 19 00:31:57 2026] [::1]:48048 Accepted
-[Thu Feb 19 00:31:57 2026] [::1]:48048 [404]: GET /uploads/ - No such file or directory
-[Thu Feb 19 00:31:57 2026] [::1]:48048 Closing
-[Thu Feb 19 00:32:58 2026] [::1]:46118 Accepted
-[Thu Feb 19 00:32:58 2026] [::1]:46118 [200]: GET /api.php?resource=health
-[Thu Feb 19 00:32:58 2026] [::1]:46118 Closing
-[Thu Feb 19 00:32:58 2026] [::1]:46128 Accepted
-[Thu Feb 19 00:32:58 2026] [::1]:46128 [200]: GET /admin.html
-[Thu Feb 19 00:32:58 2026] [::1]:46128 Closing
-[Thu Feb 19 00:32:58 2026] [::1]:46138 Accepted
-[Thu Feb 19 00:32:58 2026] [::1]:46152 Accepted
-[Thu Feb 19 00:32:58 2026] [::1]:46138 [200]: GET /styles.css
-[Thu Feb 19 00:32:58 2026] [::1]:46138 Closing
-[Thu Feb 19 00:32:58 2026] [::1]:46152 [200]: GET /admin.css
-[Thu Feb 19 00:32:58 2026] [::1]:46152 Closing
-[Thu Feb 19 00:32:58 2026] [::1]:46154 Accepted
-[Thu Feb 19 00:32:58 2026] [::1]:46154 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:32:58 2026] [::1]:46154 Closing
-[Thu Feb 19 00:32:58 2026] [::1]:46158 Accepted
-[Thu Feb 19 00:32:58 2026] [::1]:46158 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:32:58 2026] [::1]:46158 Closing
-[Thu Feb 19 00:32:59 2026] [::1]:46162 Accepted
-[Thu Feb 19 00:32:59 2026] [::1]:46162 [401]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:32:59 2026] [::1]:46162 Closing
-[Thu Feb 19 00:32:59 2026] [::1]:46170 Accepted
-[Thu Feb 19 00:32:59 2026] [::1]:46170 [200]: GET /admin.html
-[Thu Feb 19 00:32:59 2026] [::1]:46170 Closing
-[Thu Feb 19 00:32:59 2026] [::1]:46180 Accepted
-[Thu Feb 19 00:32:59 2026] [::1]:46186 Accepted
-[Thu Feb 19 00:32:59 2026] [::1]:46180 [200]: GET /styles.css
-[Thu Feb 19 00:32:59 2026] [::1]:46186 [200]: GET /admin.css
-[Thu Feb 19 00:32:59 2026] [::1]:46180 Closing
-[Thu Feb 19 00:32:59 2026] [::1]:46186 Closing
-[Thu Feb 19 00:32:59 2026] [::1]:46188 Accepted
-[Thu Feb 19 00:32:59 2026] [::1]:46188 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:32:59 2026] [::1]:46188 Closing
-[Thu Feb 19 00:32:59 2026] [::1]:46196 Accepted
-[Thu Feb 19 00:32:59 2026] [::1]:46196 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:32:59 2026] [::1]:46196 Closing
-[Thu Feb 19 00:32:59 2026] [::1]:46206 Accepted
-[Thu Feb 19 00:32:59 2026] [::1]:46206 [429]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:32:59 2026] [::1]:46206 Closing
-[Thu Feb 19 00:33:11 2026] [::1]:54762 Accepted
-[Thu Feb 19 00:33:11 2026] [::1]:54762 [200]: GET /index.html
-[Thu Feb 19 00:33:11 2026] [::1]:54762 Closing
-[Thu Feb 19 00:33:11 2026] [::1]:54766 Accepted
-[Thu Feb 19 00:33:11 2026] [::1]:54766 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:33:11 2026] [::1]:54766 Closing
-[Thu Feb 19 00:33:11 2026] [::1]:54772 Accepted
-[Thu Feb 19 00:33:11 2026] [::1]:54786 Accepted
-[Thu Feb 19 00:33:11 2026] [::1]:54772 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:33:11 2026] [::1]:54786 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:33:11 2026] [::1]:54772 Closing
-[Thu Feb 19 00:33:11 2026] [::1]:54786 Closing
-[Thu Feb 19 00:33:11 2026] [::1]:54792 Accepted
-[Thu Feb 19 00:33:11 2026] [::1]:54792 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:33:11 2026] [::1]:54792 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54806 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54820 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54826 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54836 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54806 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:33:12 2026] [::1]:54820 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:33:12 2026] [::1]:54826 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:33:12 2026] [::1]:54836 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:33:12 2026] [::1]:54806 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54820 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54826 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54836 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54852 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54852 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:33:12 2026] [::1]:54852 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54856 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54860 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54856 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:33:12 2026] [::1]:54868 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54860 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:33:12 2026] [::1]:54868 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:33:12 2026] [::1]:54856 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54860 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54868 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54878 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54886 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54894 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54878 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:33:12 2026] [::1]:54878 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54902 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54886 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:33:12 2026] [::1]:54894 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:33:12 2026] [::1]:54886 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54894 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54910 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54902 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:33:12 2026] [::1]:54902 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54910 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:33:12 2026] [::1]:54910 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54918 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54918 [200]: GET /index.html
-[Thu Feb 19 00:33:12 2026] [::1]:54918 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54922 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54926 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54932 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54922 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:33:12 2026] [::1]:54926 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:33:12 2026] [::1]:54932 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:33:12 2026] [::1]:54922 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54926 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54932 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54940 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54940 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:33:12 2026] [::1]:54940 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54950 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54958 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54974 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54976 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54950 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:33:12 2026] [::1]:54950 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54958 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:33:12 2026] [::1]:54974 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:33:12 2026] [::1]:54958 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54974 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54976 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:33:12 2026] [::1]:54976 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54986 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54986 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:33:12 2026] [::1]:54986 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:54990 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:55002 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:55008 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:54990 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:33:12 2026] [::1]:54990 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:55002 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:33:12 2026] [::1]:55008 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:33:12 2026] [::1]:55002 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:55008 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:55022 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:55022 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:33:12 2026] [::1]:55022 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:55034 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:55042 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:55048 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:55054 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:55034 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:33:12 2026] [::1]:55034 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:55042 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:33:12 2026] [::1]:55048 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:33:12 2026] [::1]:55042 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:55048 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:55054 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:33:12 2026] [::1]:55054 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:55066 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:55066 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:33:12 2026] [::1]:55066 Closing
-[Thu Feb 19 00:33:12 2026] [::1]:55082 Accepted
-[Thu Feb 19 00:33:12 2026] [::1]:55082 [200]: GET /api.php?resource=booked-slots&date=2026-02-21&doctor=rosero
-[Thu Feb 19 00:33:12 2026] [::1]:55082 Closing
-[Thu Feb 19 00:33:13 2026] [::1]:55098 Accepted
-[Thu Feb 19 00:33:13 2026] [::1]:55110 Accepted
-[Thu Feb 19 00:33:13 2026] [::1]:55116 Accepted
-[Thu Feb 19 00:33:13 2026] [::1]:55128 Accepted
-[Thu Feb 19 00:33:13 2026] [::1]:55144 Accepted
-[Thu Feb 19 00:33:13 2026] [::1]:55148 Accepted
-[Thu Feb 19 00:33:13 2026] [::1]:55098 [200]: GET /images/optimized/service-consulta.avif
-[Thu Feb 19 00:33:13 2026] [::1]:55098 Closing
-[Thu Feb 19 00:33:13 2026] [::1]:55110 [200]: GET /images/optimized/service-telemedicina.avif
-[Thu Feb 19 00:33:13 2026] [::1]:55116 [200]: GET /images/optimized/service-laser.avif
-[Thu Feb 19 00:33:13 2026] [::1]:55128 [200]: GET /images/optimized/service-rejuvenecimiento.avif
-[Thu Feb 19 00:33:13 2026] [::1]:55144 [200]: GET /images/optimized/service-acne.avif
-[Thu Feb 19 00:33:13 2026] [::1]:55148 [200]: GET /images/optimized/service-cancer.avif
-[Thu Feb 19 00:33:13 2026] [::1]:55110 Closing
-[Thu Feb 19 00:33:13 2026] [::1]:55116 Closing
-[Thu Feb 19 00:33:13 2026] [::1]:55128 Closing
-[Thu Feb 19 00:33:13 2026] [::1]:55144 Closing
-[Thu Feb 19 00:33:13 2026] [::1]:55148 Closing
-[Thu Feb 19 00:33:13 2026] [::1]:55162 Accepted
-[Thu Feb 19 00:33:13 2026] [::1]:55170 Accepted
-[Thu Feb 19 00:33:13 2026] [::1]:55162 [200]: GET /images/optimized/team-rosero.avif
-[Thu Feb 19 00:33:13 2026] [::1]:55170 [200]: GET /images/optimized/team-narvaez.avif
-[Thu Feb 19 00:33:13 2026] [::1]:55162 Closing
-[Thu Feb 19 00:33:13 2026] [::1]:55170 Closing
-[Thu Feb 19 00:33:13 2026] [::1]:55172 Accepted
-[Thu Feb 19 00:33:13 2026] [::1]:55172 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:33:13 2026] [::1]:55172 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55180 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55180 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:33:15 2026] [::1]:55180 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55196 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55196 [200]: GET /index.html
-[Thu Feb 19 00:33:15 2026] [::1]:55196 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55206 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55208 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55206 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:33:15 2026] [::1]:55222 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55208 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:33:15 2026] [::1]:55222 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:33:15 2026] [::1]:55206 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55208 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55222 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55226 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55226 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:33:15 2026] [::1]:55226 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55238 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55238 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:33:15 2026] [::1]:55238 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55254 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55266 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55268 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55254 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:33:15 2026] [::1]:55254 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55266 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:33:15 2026] [::1]:55266 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55268 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:33:15 2026] [::1]:55268 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55278 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55294 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55278 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:33:15 2026] [::1]:55294 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:33:15 2026] [::1]:55278 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55294 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55306 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55308 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55322 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55338 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55354 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55370 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55306 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:33:15 2026] [::1]:55308 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:33:15 2026] [::1]:55322 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:33:15 2026] [::1]:55306 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55308 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55322 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55338 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:33:15 2026] [::1]:55338 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55354 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:33:15 2026] [::1]:55354 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55370 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:33:15 2026] [::1]:55370 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55380 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55380 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:33:15 2026] [::1]:55380 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55382 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55382 [200]: GET /index.html
-[Thu Feb 19 00:33:15 2026] [::1]:55382 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55384 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55386 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55394 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55384 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:33:15 2026] [::1]:55384 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55386 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:33:15 2026] [::1]:55386 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55394 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:33:15 2026] [::1]:55394 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55398 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55398 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:33:15 2026] [::1]:55398 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55412 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55424 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55438 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55442 Accepted
-[Thu Feb 19 00:33:15 2026] [::1]:55412 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:33:15 2026] [::1]:55424 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:33:15 2026] [::1]:55438 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:33:15 2026] [::1]:55442 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:33:15 2026] [::1]:55412 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55424 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55438 Closing
-[Thu Feb 19 00:33:15 2026] [::1]:55442 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55446 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55446 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:33:16 2026] [::1]:55446 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55454 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55458 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55474 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55476 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55492 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55504 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55454 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:33:16 2026] [::1]:55458 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:33:16 2026] [::1]:55474 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:33:16 2026] [::1]:55476 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:33:16 2026] [::1]:55492 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:33:16 2026] [::1]:55504 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:33:16 2026] [::1]:55454 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55458 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55474 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55476 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55492 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55504 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55514 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55522 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55514 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:33:16 2026] [::1]:55514 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55522 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:33:16 2026] [::1]:55522 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55536 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55536 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:33:16 2026] [::1]:55536 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55538 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55538 [200]: GET /figo-chat.php
-[Thu Feb 19 00:33:16 2026] [::1]:55538 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55546 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55546 [404]: GET /data/ - No such file or directory
-[Thu Feb 19 00:33:16 2026] [::1]:55546 Closing
-[Thu Feb 19 00:33:16 2026] [::1]:55554 Accepted
-[Thu Feb 19 00:33:16 2026] [::1]:55554 [404]: GET /uploads/ - No such file or directory
-[Thu Feb 19 00:33:16 2026] [::1]:55554 Closing
-[Thu Feb 19 00:33:48 2026] [::1]:43768 Accepted
-[Thu Feb 19 00:33:48 2026] [::1]:43768 [200]: GET /api.php?resource=health
-[Thu Feb 19 00:33:48 2026] [::1]:43768 Closing
-[Thu Feb 19 00:33:48 2026] [::1]:43778 Accepted
-[Thu Feb 19 00:33:48 2026] [::1]:43778 [200]: GET /admin.html
-[Thu Feb 19 00:33:48 2026] [::1]:43778 Closing
-[Thu Feb 19 00:33:48 2026] [::1]:43794 Accepted
-[Thu Feb 19 00:33:48 2026] [::1]:43804 Accepted
-[Thu Feb 19 00:33:48 2026] [::1]:43794 [200]: GET /styles.css
-[Thu Feb 19 00:33:48 2026] [::1]:43804 [200]: GET /admin.css
-[Thu Feb 19 00:33:48 2026] [::1]:43794 Closing
-[Thu Feb 19 00:33:48 2026] [::1]:43804 Closing
-[Thu Feb 19 00:33:48 2026] [::1]:43810 Accepted
-[Thu Feb 19 00:33:48 2026] [::1]:43810 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:33:48 2026] [::1]:43810 Closing
-[Thu Feb 19 00:33:48 2026] [::1]:43820 Accepted
-[Thu Feb 19 00:33:48 2026] [::1]:43820 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:33:48 2026] [::1]:43820 Closing
-[Thu Feb 19 00:33:48 2026] [::1]:43832 Accepted
-[Thu Feb 19 00:33:48 2026] [::1]:43832 [429]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:33:48 2026] [::1]:43832 Closing
-[Thu Feb 19 00:33:49 2026] [::1]:43836 Accepted
-[Thu Feb 19 00:33:49 2026] [::1]:43836 [200]: GET /admin.html
-[Thu Feb 19 00:33:49 2026] [::1]:43836 Closing
-[Thu Feb 19 00:33:49 2026] [::1]:43848 Accepted
-[Thu Feb 19 00:33:49 2026] [::1]:43862 Accepted
-[Thu Feb 19 00:33:49 2026] [::1]:43848 [200]: GET /styles.css
-[Thu Feb 19 00:33:49 2026] [::1]:43862 [200]: GET /admin.css
-[Thu Feb 19 00:33:49 2026] [::1]:43848 Closing
-[Thu Feb 19 00:33:49 2026] [::1]:43862 Closing
-[Thu Feb 19 00:33:49 2026] [::1]:43870 Accepted
-[Thu Feb 19 00:33:49 2026] [::1]:43870 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:33:49 2026] [::1]:43870 Closing
-[Thu Feb 19 00:33:49 2026] [::1]:43886 Accepted
-[Thu Feb 19 00:33:49 2026] [::1]:43886 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:33:49 2026] [::1]:43886 Closing
-[Thu Feb 19 00:33:49 2026] [::1]:43902 Accepted
-[Thu Feb 19 00:33:49 2026] [::1]:43902 [429]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:33:49 2026] [::1]:43902 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:34646 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:34646 [200]: GET /index.html
-[Thu Feb 19 00:34:06 2026] [::1]:34646 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:34660 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:34670 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:34686 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:34660 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:34:06 2026] [::1]:34670 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:34:06 2026] [::1]:34686 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:34:06 2026] [::1]:34660 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:34670 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:34686 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:34690 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:34690 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:34:06 2026] [::1]:34690 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:34698 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:34698 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:34:06 2026] [::1]:34698 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:34702 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:34716 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:34728 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:34702 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:34:06 2026] [::1]:34702 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:34716 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:34:06 2026] [::1]:34716 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:34728 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:34:06 2026] [::1]:34728 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:36432 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:36434 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:36444 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:36448 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:36456 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:36468 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:36432 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:34:06 2026] [::1]:36434 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:34:06 2026] [::1]:36444 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:34:06 2026] [::1]:36448 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:34:06 2026] [::1]:36456 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:34:06 2026] [::1]:36468 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:34:06 2026] [::1]:36432 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:36434 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:36444 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:36448 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:36456 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:36468 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:36470 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:36486 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:36502 Accepted
-[Thu Feb 19 00:34:06 2026] [::1]:36470 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:34:06 2026] [::1]:36470 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:36486 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:34:06 2026] [::1]:36486 Closing
-[Thu Feb 19 00:34:06 2026] [::1]:36502 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:34:06 2026] [::1]:36502 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36518 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36518 [200]: GET /index.html
-[Thu Feb 19 00:34:07 2026] [::1]:36518 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36534 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36550 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36534 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:34:07 2026] [::1]:36552 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36550 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:34:07 2026] [::1]:36552 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:34:07 2026] [::1]:36534 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36550 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36552 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36558 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36558 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:34:07 2026] [::1]:36558 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36560 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36576 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36578 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36590 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36560 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:34:07 2026] [::1]:36560 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36576 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:34:07 2026] [::1]:36576 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36578 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:34:07 2026] [::1]:36578 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36590 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:34:07 2026] [::1]:36590 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36598 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36598 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:34:07 2026] [::1]:36598 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36602 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36602 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:34:07 2026] [::1]:36602 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36614 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36620 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36614 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:34:07 2026] [::1]:36636 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36620 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:34:07 2026] [::1]:36644 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36636 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:34:07 2026] [::1]:36614 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36644 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:34:07 2026] [::1]:36620 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36636 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36644 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36658 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36658 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:34:07 2026] [::1]:36658 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36674 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36682 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36674 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:34:07 2026] [::1]:36682 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:34:07 2026] [::1]:36674 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36682 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36684 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36684 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:34:07 2026] [::1]:36684 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36688 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36688 [200]: GET /api.php?resource=booked-slots&date=2026-02-21&doctor=rosero
-[Thu Feb 19 00:34:07 2026] [::1]:36688 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36700 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36710 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36712 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36718 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36720 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36726 Accepted
-[Thu Feb 19 00:34:07 2026] [::1]:36700 [200]: GET /images/optimized/service-consulta.avif
-[Thu Feb 19 00:34:07 2026] [::1]:36710 [200]: GET /images/optimized/service-telemedicina.avif
-[Thu Feb 19 00:34:07 2026] [::1]:36700 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36710 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36712 [200]: GET /images/optimized/service-laser.avif
-[Thu Feb 19 00:34:07 2026] [::1]:36712 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36718 [200]: GET /images/optimized/service-rejuvenecimiento.avif
-[Thu Feb 19 00:34:07 2026] [::1]:36718 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36720 [200]: GET /images/optimized/service-acne.avif
-[Thu Feb 19 00:34:07 2026] [::1]:36720 Closing
-[Thu Feb 19 00:34:07 2026] [::1]:36726 [200]: GET /images/optimized/service-cancer.avif
-[Thu Feb 19 00:34:07 2026] [::1]:36726 Closing
-[Thu Feb 19 00:34:08 2026] [::1]:36736 Accepted
-[Thu Feb 19 00:34:08 2026] [::1]:36748 Accepted
-[Thu Feb 19 00:34:08 2026] [::1]:36736 [200]: GET /images/optimized/team-rosero.avif
-[Thu Feb 19 00:34:08 2026] [::1]:36748 [200]: GET /images/optimized/team-narvaez.avif
-[Thu Feb 19 00:34:08 2026] [::1]:36736 Closing
-[Thu Feb 19 00:34:08 2026] [::1]:36748 Closing
-[Thu Feb 19 00:34:08 2026] [::1]:36764 Accepted
-[Thu Feb 19 00:34:08 2026] [::1]:36764 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:34:08 2026] [::1]:36764 Closing
-[Thu Feb 19 00:34:09 2026] [::1]:36780 Accepted
-[Thu Feb 19 00:34:09 2026] [::1]:36780 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:34:09 2026] [::1]:36780 Closing
-[Thu Feb 19 00:34:09 2026] [::1]:36786 Accepted
-[Thu Feb 19 00:34:09 2026] [::1]:36786 [200]: GET /index.html
-[Thu Feb 19 00:34:09 2026] [::1]:36786 Closing
-[Thu Feb 19 00:34:09 2026] [::1]:36790 Accepted
-[Thu Feb 19 00:34:09 2026] [::1]:36804 Accepted
-[Thu Feb 19 00:34:09 2026] [::1]:36806 Accepted
-[Thu Feb 19 00:34:09 2026] [::1]:36790 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:34:09 2026] [::1]:36804 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:34:09 2026] [::1]:36806 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:34:09 2026] [::1]:36790 Closing
-[Thu Feb 19 00:34:09 2026] [::1]:36804 Closing
-[Thu Feb 19 00:34:09 2026] [::1]:36806 Closing
-[Thu Feb 19 00:34:09 2026] [::1]:36822 Accepted
-[Thu Feb 19 00:34:09 2026] [::1]:36822 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:34:09 2026] [::1]:36822 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36836 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36840 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36854 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36856 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36836 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:34:10 2026] [::1]:36840 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:34:10 2026] [::1]:36854 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:34:10 2026] [::1]:36856 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:34:10 2026] [::1]:36836 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36840 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36854 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36856 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36862 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36878 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36862 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:34:10 2026] [::1]:36882 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36878 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:34:10 2026] [::1]:36890 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36882 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:34:10 2026] [::1]:36906 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36862 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36890 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:34:10 2026] [::1]:36920 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36878 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36906 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:34:10 2026] [::1]:36920 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:34:10 2026] [::1]:36882 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36890 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36906 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36920 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36924 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36934 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36924 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:34:10 2026] [::1]:36946 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36934 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:34:10 2026] [::1]:36946 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:34:10 2026] [::1]:36924 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36934 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36946 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36958 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36958 [200]: GET /index.html
-[Thu Feb 19 00:34:10 2026] [::1]:36958 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36972 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36978 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36984 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36972 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:34:10 2026] [::1]:36972 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36978 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:34:10 2026] [::1]:36978 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36984 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:34:10 2026] [::1]:36984 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36996 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36996 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:34:10 2026] [::1]:36996 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:36998 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37014 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37026 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37040 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:36998 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:34:10 2026] [::1]:37014 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:34:10 2026] [::1]:36998 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37026 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:34:10 2026] [::1]:37014 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37026 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37040 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:34:10 2026] [::1]:37040 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37042 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37042 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:34:10 2026] [::1]:37042 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37046 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37046 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:34:10 2026] [::1]:37046 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37052 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37052 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:34:10 2026] [::1]:37052 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37062 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37062 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:34:10 2026] [::1]:37062 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37068 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37068 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:34:10 2026] [::1]:37068 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37078 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37084 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37078 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:34:10 2026] [::1]:37100 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37084 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:34:10 2026] [::1]:37100 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:34:10 2026] [::1]:37078 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37084 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37100 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37102 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37102 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:34:10 2026] [::1]:37102 Closing
-[Thu Feb 19 00:34:10 2026] [::1]:37110 Accepted
-[Thu Feb 19 00:34:10 2026] [::1]:37110 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:34:10 2026] [::1]:37110 Closing
-[Thu Feb 19 00:34:11 2026] [::1]:37120 Accepted
-[Thu Feb 19 00:34:11 2026] [::1]:37120 [200]: GET /figo-chat.php
-[Thu Feb 19 00:34:11 2026] [::1]:37120 Closing
-[Thu Feb 19 00:34:11 2026] [::1]:37126 Accepted
-[Thu Feb 19 00:34:11 2026] [::1]:37126 [404]: GET /data/ - No such file or directory
-[Thu Feb 19 00:34:11 2026] [::1]:37126 Closing
-[Thu Feb 19 00:34:11 2026] [::1]:37132 Accepted
-[Thu Feb 19 00:34:11 2026] [::1]:37132 [404]: GET /uploads/ - No such file or directory
-[Thu Feb 19 00:34:11 2026] [::1]:37132 Closing
-[Thu Feb 19 00:34:49 2026] [::1]:51928 Accepted
-[Thu Feb 19 00:34:49 2026] [::1]:51928 [200]: GET /api.php?resource=health
-[Thu Feb 19 00:34:49 2026] [::1]:51928 Closing
-[Thu Feb 19 00:34:49 2026] [::1]:51930 Accepted
-[Thu Feb 19 00:34:49 2026] [::1]:51930 [200]: GET /admin.html
-[Thu Feb 19 00:34:49 2026] [::1]:51930 Closing
-[Thu Feb 19 00:34:49 2026] [::1]:51936 Accepted
-[Thu Feb 19 00:34:49 2026] [::1]:51950 Accepted
-[Thu Feb 19 00:34:49 2026] [::1]:51936 [200]: GET /styles.css
-[Thu Feb 19 00:34:49 2026] [::1]:51950 [200]: GET /admin.css
-[Thu Feb 19 00:34:49 2026] [::1]:51936 Closing
-[Thu Feb 19 00:34:49 2026] [::1]:51950 Closing
-[Thu Feb 19 00:34:49 2026] [::1]:51966 Accepted
-[Thu Feb 19 00:34:49 2026] [::1]:51966 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:34:49 2026] [::1]:51966 Closing
-[Thu Feb 19 00:34:49 2026] [::1]:51968 Accepted
-[Thu Feb 19 00:34:49 2026] [::1]:51968 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:34:49 2026] [::1]:51968 Closing
-[Thu Feb 19 00:34:50 2026] [::1]:51974 Accepted
-[Thu Feb 19 00:34:50 2026] [::1]:51974 [401]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:34:50 2026] [::1]:51974 Closing
-[Thu Feb 19 00:34:50 2026] [::1]:51976 Accepted
-[Thu Feb 19 00:34:50 2026] [::1]:51976 [200]: GET /admin.html
-[Thu Feb 19 00:34:50 2026] [::1]:51976 Closing
-[Thu Feb 19 00:34:50 2026] [::1]:51992 Accepted
-[Thu Feb 19 00:34:50 2026] [::1]:52006 Accepted
-[Thu Feb 19 00:34:50 2026] [::1]:51992 [200]: GET /styles.css
-[Thu Feb 19 00:34:50 2026] [::1]:51992 Closing
-[Thu Feb 19 00:34:50 2026] [::1]:52006 [200]: GET /admin.css
-[Thu Feb 19 00:34:50 2026] [::1]:52006 Closing
-[Thu Feb 19 00:34:50 2026] [::1]:52016 Accepted
-[Thu Feb 19 00:34:50 2026] [::1]:52016 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:34:50 2026] [::1]:52016 Closing
-[Thu Feb 19 00:34:50 2026] [::1]:52030 Accepted
-[Thu Feb 19 00:34:50 2026] [::1]:52030 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:34:50 2026] [::1]:52030 Closing
-[Thu Feb 19 00:34:50 2026] [::1]:52044 Accepted
-[Thu Feb 19 00:34:50 2026] [::1]:52044 [200]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:34:50 2026] [::1]:52044 Closing
-[Thu Feb 19 00:34:50 2026] [::1]:52058 Accepted
-[Thu Feb 19 00:34:50 2026] [::1]:52058 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:34:50 2026] [::1]:52058 Closing
-[Thu Feb 19 00:34:50 2026] [::1]:52062 Accepted
-[Thu Feb 19 00:34:50 2026] [::1]:52062 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:34:50 2026] [::1]:52062 Closing
-[Thu Feb 19 00:34:51 2026] [::1]:52078 Accepted
-[Thu Feb 19 00:34:51 2026] [::1]:52078 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:34:51 2026] [::1]:52078 Closing
-[Thu Feb 19 00:34:52 2026] [::1]:52086 Accepted
-[Thu Feb 19 00:34:52 2026] [::1]:52086 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:34:52 2026] [::1]:52086 Closing
-[Thu Feb 19 00:34:52 2026] [::1]:52100 Accepted
-[Thu Feb 19 00:34:52 2026] [::1]:52100 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:34:52 2026] [::1]:52100 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52116 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52116 [200]: GET /index.html
-[Thu Feb 19 00:34:53 2026] [::1]:52116 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52128 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52138 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52128 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:34:53 2026] [::1]:52138 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:34:53 2026] [::1]:52128 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52138 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52142 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52142 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:34:53 2026] [::1]:52142 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52154 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52154 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:34:53 2026] [::1]:52154 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52158 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52166 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52168 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52176 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52158 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:34:53 2026] [::1]:52166 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:34:53 2026] [::1]:52168 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:34:53 2026] [::1]:52176 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:34:53 2026] [::1]:52158 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52166 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52168 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52176 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52190 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52194 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52190 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:34:53 2026] [::1]:52194 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:34:53 2026] [::1]:52190 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52194 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52206 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52216 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52224 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52230 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52234 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52206 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:34:53 2026] [::1]:52206 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52244 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52216 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:34:53 2026] [::1]:52216 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52224 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:34:53 2026] [::1]:52224 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52230 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:34:53 2026] [::1]:52230 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52234 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:34:53 2026] [::1]:52234 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52244 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:34:53 2026] [::1]:52244 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52260 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52260 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:34:53 2026] [::1]:52260 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52268 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52268 [200]: GET /index.html
-[Thu Feb 19 00:34:53 2026] [::1]:52268 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52274 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52284 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52294 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52274 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:34:53 2026] [::1]:52284 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:34:53 2026] [::1]:52294 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:34:53 2026] [::1]:52274 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52284 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52294 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52302 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52302 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:34:53 2026] [::1]:52302 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52312 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52322 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52328 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52330 Accepted
-[Thu Feb 19 00:34:53 2026] [::1]:52312 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:34:53 2026] [::1]:52322 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:34:53 2026] [::1]:52328 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:34:53 2026] [::1]:52330 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:34:53 2026] [::1]:52312 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52322 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52328 Closing
-[Thu Feb 19 00:34:53 2026] [::1]:52330 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52346 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52346 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:34:54 2026] [::1]:52346 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52362 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52374 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52386 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52394 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52404 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52418 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52362 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:34:54 2026] [::1]:52362 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52374 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:34:54 2026] [::1]:52374 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52422 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52386 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:34:54 2026] [::1]:52394 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:34:54 2026] [::1]:52404 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:34:54 2026] [::1]:52418 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:34:54 2026] [::1]:52434 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52422 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:34:54 2026] [::1]:52434 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:34:54 2026] [::1]:52386 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52394 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52404 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52418 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52422 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52434 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52448 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52448 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:34:54 2026] [::1]:52448 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52454 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52454 [200]: GET /api.php?resource=booked-slots&date=2026-02-21&doctor=rosero
-[Thu Feb 19 00:34:54 2026] [::1]:52454 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52466 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52476 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52484 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52492 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52504 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52510 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52466 [200]: GET /images/optimized/service-consulta.avif
-[Thu Feb 19 00:34:54 2026] [::1]:52476 [200]: GET /images/optimized/service-telemedicina.avif
-[Thu Feb 19 00:34:54 2026] [::1]:52484 [200]: GET /images/optimized/service-laser.avif
-[Thu Feb 19 00:34:54 2026] [::1]:52466 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52476 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52484 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52492 [200]: GET /images/optimized/service-rejuvenecimiento.avif
-[Thu Feb 19 00:34:54 2026] [::1]:52492 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52504 [200]: GET /images/optimized/service-acne.avif
-[Thu Feb 19 00:34:54 2026] [::1]:52504 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52510 [200]: GET /images/optimized/service-cancer.avif
-[Thu Feb 19 00:34:54 2026] [::1]:52510 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52522 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52534 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52522 [200]: GET /images/optimized/team-rosero.avif
-[Thu Feb 19 00:34:54 2026] [::1]:52522 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52534 [200]: GET /images/optimized/team-narvaez.avif
-[Thu Feb 19 00:34:54 2026] [::1]:52534 Closing
-[Thu Feb 19 00:34:54 2026] [::1]:52542 Accepted
-[Thu Feb 19 00:34:54 2026] [::1]:52542 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:34:54 2026] [::1]:52542 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52546 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52546 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:34:56 2026] [::1]:52546 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52550 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52550 [200]: GET /index.html
-[Thu Feb 19 00:34:56 2026] [::1]:52550 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52560 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52562 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52570 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52560 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:34:56 2026] [::1]:52560 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52562 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:34:56 2026] [::1]:52562 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52570 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:34:56 2026] [::1]:52570 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52586 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52586 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:34:56 2026] [::1]:52586 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52594 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52608 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52612 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52622 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52594 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:34:56 2026] [::1]:52594 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52608 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:34:56 2026] [::1]:52608 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52612 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:34:56 2026] [::1]:52612 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52622 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:34:56 2026] [::1]:52622 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52628 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52628 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:34:56 2026] [::1]:52628 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52640 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52640 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:34:56 2026] [::1]:52640 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52652 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52666 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52652 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:34:56 2026] [::1]:52670 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52666 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:34:56 2026] [::1]:52676 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52670 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:34:56 2026] [::1]:52652 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52676 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:34:56 2026] [::1]:52666 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52670 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52676 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52678 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52678 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:34:56 2026] [::1]:52678 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52688 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52694 Accepted
-[Thu Feb 19 00:34:56 2026] [::1]:52688 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:34:56 2026] [::1]:52688 Closing
-[Thu Feb 19 00:34:56 2026] [::1]:52694 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:34:56 2026] [::1]:52694 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36678 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36678 [200]: GET /index.html
-[Thu Feb 19 00:34:57 2026] [::1]:36678 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36682 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36696 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36704 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36682 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:34:57 2026] [::1]:36696 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:34:57 2026] [::1]:36704 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:34:57 2026] [::1]:36682 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36696 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36704 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36716 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36716 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:34:57 2026] [::1]:36716 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36722 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36732 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36746 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36758 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36722 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:34:57 2026] [::1]:36722 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36732 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:34:57 2026] [::1]:36732 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36746 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:34:57 2026] [::1]:36746 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36758 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:34:57 2026] [::1]:36758 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36766 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36780 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36766 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:34:57 2026] [::1]:36786 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36780 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:34:57 2026] [::1]:36788 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36786 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:34:57 2026] [::1]:36798 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36766 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36788 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:34:57 2026] [::1]:36804 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36780 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36798 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:34:57 2026] [::1]:36804 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:34:57 2026] [::1]:36786 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36788 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36798 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36804 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36812 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36812 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:34:57 2026] [::1]:36812 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36824 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36824 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:34:57 2026] [::1]:36824 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36840 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36840 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:34:57 2026] [::1]:36840 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36854 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36854 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:34:57 2026] [::1]:36854 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36866 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36866 [200]: GET /figo-chat.php
-[Thu Feb 19 00:34:57 2026] [::1]:36866 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36882 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36882 [404]: GET /data/ - No such file or directory
-[Thu Feb 19 00:34:57 2026] [::1]:36882 Closing
-[Thu Feb 19 00:34:57 2026] [::1]:36896 Accepted
-[Thu Feb 19 00:34:57 2026] [::1]:36896 [404]: GET /uploads/ - No such file or directory
-[Thu Feb 19 00:34:57 2026] [::1]:36896 Closing
-[Thu Feb 19 00:35:53 2026] [::1]:34692 Accepted
-[Thu Feb 19 00:35:53 2026] [::1]:34692 [200]: GET /
-[Thu Feb 19 00:35:53 2026] [::1]:34692 Closing
-[Thu Feb 19 00:35:53 2026] [::1]:34694 Accepted
-[Thu Feb 19 00:35:53 2026] [::1]:34694 [200]: GET /admin.html
-[Thu Feb 19 00:35:53 2026] [::1]:34694 Closing
-[Thu Feb 19 00:35:53 2026] [::1]:34702 Accepted
-[Thu Feb 19 00:35:53 2026] [::1]:34714 Accepted
-[Thu Feb 19 00:35:53 2026] [::1]:34722 Accepted
-[Thu Feb 19 00:35:53 2026] [::1]:34702 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:35:53 2026] [::1]:34714 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:35:53 2026] [::1]:34722 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:35:53 2026] [::1]:34702 Closing
-[Thu Feb 19 00:35:53 2026] [::1]:34714 Closing
-[Thu Feb 19 00:35:53 2026] [::1]:34722 Closing
-[Thu Feb 19 00:35:53 2026] [::1]:34730 Accepted
-[Thu Feb 19 00:35:53 2026] [::1]:34746 Accepted
-[Thu Feb 19 00:35:53 2026] [::1]:34730 [200]: GET /styles.css
-[Thu Feb 19 00:35:53 2026] [::1]:34746 [200]: GET /admin.css
-[Thu Feb 19 00:35:53 2026] [::1]:34730 Closing
-[Thu Feb 19 00:35:53 2026] [::1]:34746 Closing
-[Thu Feb 19 00:35:53 2026] [::1]:34758 Accepted
-[Thu Feb 19 00:35:53 2026] [::1]:34758 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:35:53 2026] [::1]:34758 Closing
-[Thu Feb 19 00:35:53 2026] [::1]:34768 Accepted
-[Thu Feb 19 00:35:53 2026] [::1]:34768 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:35:53 2026] [::1]:34768 Closing
-[Thu Feb 19 00:35:53 2026] [::1]:34782 Accepted
-[Thu Feb 19 00:35:53 2026] [::1]:34782 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:35:53 2026] [::1]:34782 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34796 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34796 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:35:54 2026] [::1]:34796 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34804 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34804 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:35:54 2026] [::1]:34804 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34812 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34812 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:35:54 2026] [::1]:34812 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34828 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34828 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:35:54 2026] [::1]:34828 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34844 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34848 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34844 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:35:54 2026] [::1]:34850 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34848 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:35:54 2026] [::1]:34850 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:35:54 2026] [::1]:34844 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34848 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34850 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34860 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34868 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34860 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:35:54 2026] [::1]:34868 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:35:54 2026] [::1]:34860 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34868 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34884 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34888 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34884 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:35:54 2026] [::1]:34888 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:35:54 2026] [::1]:34884 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34888 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34902 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34918 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34902 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:35:54 2026] [::1]:34918 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:35:54 2026] [::1]:34902 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34918 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34928 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34928 [200]: GET /admin.html
-[Thu Feb 19 00:35:54 2026] [::1]:34928 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34934 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34934 [200]: GET /styles.css
-[Thu Feb 19 00:35:54 2026] [::1]:34934 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34946 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34946 [200]: GET /admin.css
-[Thu Feb 19 00:35:54 2026] [::1]:34946 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34952 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34952 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:35:54 2026] [::1]:34952 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34968 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34968 [200]: GET /
-[Thu Feb 19 00:35:54 2026] [::1]:34968 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:34984 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:35000 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:35016 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:34984 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:35:54 2026] [::1]:34984 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:35000 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:35:54 2026] [::1]:35000 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:35016 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:35:54 2026] [::1]:35016 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:35026 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:35026 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:35:54 2026] [::1]:35026 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:35030 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:35030 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:35:54 2026] [::1]:35030 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:35032 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:35048 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:35054 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:35064 Accepted
-[Thu Feb 19 00:35:54 2026] [::1]:35032 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:35:54 2026] [::1]:35048 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:35:54 2026] [::1]:35054 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:35:54 2026] [::1]:35064 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:35:54 2026] [::1]:35032 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:35048 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:35054 Closing
-[Thu Feb 19 00:35:54 2026] [::1]:35064 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35076 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35084 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35076 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:35:55 2026] [::1]:35076 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35084 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:35:55 2026] [::1]:35084 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35086 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35098 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35108 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35120 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35136 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35146 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35086 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:35:55 2026] [::1]:35098 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:35:55 2026] [::1]:35108 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:35:55 2026] [::1]:35120 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:35:55 2026] [::1]:35136 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:35:55 2026] [::1]:35086 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35098 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35108 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35120 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35136 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35150 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35146 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:35:55 2026] [::1]:35150 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:35:55 2026] [::1]:35146 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35150 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35160 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35160 [200]: GET /admin.html
-[Thu Feb 19 00:35:55 2026] [::1]:35160 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35162 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35176 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35162 [200]: GET /styles.css
-[Thu Feb 19 00:35:55 2026] [::1]:35176 [200]: GET /admin.css
-[Thu Feb 19 00:35:55 2026] [::1]:35162 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35176 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35186 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35186 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:35:55 2026] [::1]:35186 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35194 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35194 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:35:55 2026] [::1]:35194 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35206 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35206 [200]: GET /
-[Thu Feb 19 00:35:55 2026] [::1]:35206 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35222 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35226 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35238 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35222 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:35:55 2026] [::1]:35226 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:35:55 2026] [::1]:35238 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:35:55 2026] [::1]:35222 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35226 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35238 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35242 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35242 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:35:55 2026] [::1]:35242 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35250 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35254 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35264 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35280 Accepted
-[Thu Feb 19 00:35:55 2026] [::1]:35250 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:35:55 2026] [::1]:35250 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35254 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:35:55 2026] [::1]:35254 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35264 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:35:55 2026] [::1]:35280 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:35:55 2026] [::1]:35264 Closing
-[Thu Feb 19 00:35:55 2026] [::1]:35280 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35294 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35294 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:35:56 2026] [::1]:35294 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35302 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35306 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35302 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:35:56 2026] [::1]:35310 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35306 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:35:56 2026] [::1]:35316 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35310 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:35:56 2026] [::1]:35302 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35316 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:35:56 2026] [::1]:35306 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35310 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35316 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35330 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35336 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35330 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:35:56 2026] [::1]:35330 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35336 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:35:56 2026] [::1]:35336 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35352 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35356 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35352 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:35:56 2026] [::1]:35356 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:35:56 2026] [::1]:35352 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35356 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35362 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35362 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:35:56 2026] [::1]:35362 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35376 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35376 [200]: GET /api.php?resource=booked-slots&date=2026-02-20&doctor=rosero
-[Thu Feb 19 00:35:56 2026] [::1]:35376 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35390 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35392 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35390 [200]: GET /images/optimized/service-consulta.avif
-[Thu Feb 19 00:35:56 2026] [::1]:35394 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35392 [200]: GET /images/optimized/service-telemedicina.avif
-[Thu Feb 19 00:35:56 2026] [::1]:35408 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35394 [200]: GET /images/optimized/service-laser.avif
-[Thu Feb 19 00:35:56 2026] [::1]:35416 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35390 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35408 [200]: GET /images/optimized/service-rejuvenecimiento.avif
-[Thu Feb 19 00:35:56 2026] [::1]:35428 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35392 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35416 [200]: GET /images/optimized/service-acne.avif
-[Thu Feb 19 00:35:56 2026] [::1]:35428 [200]: GET /images/optimized/service-cancer.avif
-[Thu Feb 19 00:35:56 2026] [::1]:35394 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35408 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35416 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35428 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35444 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35446 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:35444 [200]: GET /images/optimized/team-rosero.avif
-[Thu Feb 19 00:35:56 2026] [::1]:35446 [200]: GET /images/optimized/team-narvaez.avif
-[Thu Feb 19 00:35:56 2026] [::1]:35444 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:35446 Closing
-[Thu Feb 19 00:35:56 2026] [::1]:34148 Accepted
-[Thu Feb 19 00:35:56 2026] [::1]:34148 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:35:56 2026] [::1]:34148 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34162 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34162 [200]: GET /admin.html
-[Thu Feb 19 00:35:57 2026] [::1]:34162 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34168 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34176 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34168 [200]: GET /styles.css
-[Thu Feb 19 00:35:57 2026] [::1]:34176 [200]: GET /admin.css
-[Thu Feb 19 00:35:57 2026] [::1]:34168 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34176 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34186 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34186 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:35:57 2026] [::1]:34186 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34194 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34194 [200]: GET /
-[Thu Feb 19 00:35:57 2026] [::1]:34194 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34204 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34208 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34222 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34204 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:35:57 2026] [::1]:34204 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34208 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:35:57 2026] [::1]:34208 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34222 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:35:57 2026] [::1]:34222 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34230 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34230 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:35:57 2026] [::1]:34230 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34244 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34244 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:35:57 2026] [::1]:34244 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34254 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34262 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34254 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:35:57 2026] [::1]:34266 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34278 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34254 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34262 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:35:57 2026] [::1]:34266 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:35:57 2026] [::1]:34262 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34278 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:35:57 2026] [::1]:34266 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34278 Closing
-[Thu Feb 19 00:35:57 2026] [::1]:34284 Accepted
-[Thu Feb 19 00:35:57 2026] [::1]:34284 [429]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:35:57 2026] [::1]:34284 Closing
-[Thu Feb 19 00:35:58 2026] [::1]:34298 Accepted
-[Thu Feb 19 00:35:58 2026] [::1]:34298 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:35:58 2026] [::1]:34298 Closing
-[Thu Feb 19 00:35:58 2026] [::1]:34306 Accepted
-[Thu Feb 19 00:35:58 2026] [::1]:34322 Accepted
-[Thu Feb 19 00:35:58 2026] [::1]:34338 Accepted
-[Thu Feb 19 00:35:58 2026] [::1]:34352 Accepted
-[Thu Feb 19 00:35:58 2026] [::1]:34306 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:35:58 2026] [::1]:34322 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:35:58 2026] [::1]:34306 Closing
-[Thu Feb 19 00:35:58 2026] [::1]:34338 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:35:58 2026] [::1]:34322 Closing
-[Thu Feb 19 00:35:58 2026] [::1]:34338 Closing
-[Thu Feb 19 00:35:58 2026] [::1]:34352 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:35:58 2026] [::1]:34352 Closing
-[Thu Feb 19 00:35:58 2026] [::1]:34356 Accepted
-[Thu Feb 19 00:35:58 2026] [::1]:34356 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:35:58 2026] [::1]:34356 Closing
-[Thu Feb 19 00:35:58 2026] [::1]:34370 Accepted
-[Thu Feb 19 00:35:58 2026] [::1]:34370 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:35:58 2026] [::1]:34370 Closing
-[Thu Feb 19 00:35:58 2026] [::1]:34380 Accepted
-[Thu Feb 19 00:35:58 2026] [::1]:34380 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:35:58 2026] [::1]:34380 Closing
-[Thu Feb 19 00:35:58 2026] [::1]:34394 Accepted
-[Thu Feb 19 00:35:58 2026] [::1]:34394 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:35:58 2026] [::1]:34394 Closing
-[Thu Feb 19 00:35:58 2026] [::1]:34410 Accepted
-[Thu Feb 19 00:35:58 2026] [::1]:34410 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:35:58 2026] [::1]:34410 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34424 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34424 [200]: GET /
-[Thu Feb 19 00:35:59 2026] [::1]:34424 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34432 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34446 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34458 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34432 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:35:59 2026] [::1]:34432 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34446 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:35:59 2026] [::1]:34446 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34458 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:35:59 2026] [::1]:34458 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34460 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34460 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:35:59 2026] [::1]:34460 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34470 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34476 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34480 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34492 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34470 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:35:59 2026] [::1]:34476 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:35:59 2026] [::1]:34480 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:35:59 2026] [::1]:34492 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:35:59 2026] [::1]:34470 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34476 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34480 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34492 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34506 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34510 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34506 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:35:59 2026] [::1]:34510 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:35:59 2026] [::1]:34506 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34510 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34516 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34530 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34546 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34558 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34570 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34516 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:35:59 2026] [::1]:34530 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:35:59 2026] [::1]:34546 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:35:59 2026] [::1]:34558 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:35:59 2026] [::1]:34572 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34516 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34530 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34546 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34558 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34570 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:35:59 2026] [::1]:34570 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34572 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:35:59 2026] [::1]:34572 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34582 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34582 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:35:59 2026] [::1]:34582 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34586 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34586 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:35:59 2026] [::1]:34586 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34588 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34588 [200]: GET /api.php?resource=booked-slots&date=2026-02-26&doctor=rosero
-[Thu Feb 19 00:35:59 2026] [::1]:34588 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34590 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34594 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34606 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34622 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34630 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34638 Accepted
-[Thu Feb 19 00:35:59 2026] [::1]:34590 [200]: GET /images/optimized/service-consulta.avif
-[Thu Feb 19 00:35:59 2026] [::1]:34594 [200]: GET /images/optimized/service-telemedicina.avif
-[Thu Feb 19 00:35:59 2026] [::1]:34606 [200]: GET /images/optimized/service-laser.avif
-[Thu Feb 19 00:35:59 2026] [::1]:34590 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34594 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34606 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34622 [200]: GET /images/optimized/service-rejuvenecimiento.avif
-[Thu Feb 19 00:35:59 2026] [::1]:34622 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34630 [200]: GET /images/optimized/service-acne.avif
-[Thu Feb 19 00:35:59 2026] [::1]:34630 Closing
-[Thu Feb 19 00:35:59 2026] [::1]:34638 [200]: GET /images/optimized/service-cancer.avif
-[Thu Feb 19 00:35:59 2026] [::1]:34638 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34640 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34650 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34640 [200]: GET /images/optimized/team-rosero.avif
-[Thu Feb 19 00:36:00 2026] [::1]:34650 [200]: GET /images/optimized/team-narvaez.avif
-[Thu Feb 19 00:36:00 2026] [::1]:34640 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34650 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34660 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34660 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:36:00 2026] [::1]:34660 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34670 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34670 [200]: GET /api.php?resource=health
-[Thu Feb 19 00:36:00 2026] [::1]:34670 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34684 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34684 [401]: GET /api.php?resource=data
-[Thu Feb 19 00:36:00 2026] [::1]:34684 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34700 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34700 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:36:00 2026] [::1]:34700 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34704 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34704 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:36:00 2026] [::1]:34704 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34720 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34720 [200]: GET /api.php?resource=health
-[Thu Feb 19 00:36:00 2026] [::1]:34720 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34726 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34726 [200]: GET /admin.html
-[Thu Feb 19 00:36:00 2026] [::1]:34726 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34742 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34744 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34742 [200]: GET /styles.css
-[Thu Feb 19 00:36:00 2026] [::1]:34744 [200]: GET /admin.css
-[Thu Feb 19 00:36:00 2026] [::1]:34742 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34744 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34756 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34756 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:36:00 2026] [::1]:34756 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34770 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34770 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:36:00 2026] [::1]:34770 Closing
-[Thu Feb 19 00:36:00 2026] [::1]:34776 Accepted
-[Thu Feb 19 00:36:00 2026] [::1]:34776 [429]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:36:00 2026] [::1]:34776 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34788 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34788 [200]: GET /admin.html
-[Thu Feb 19 00:36:01 2026] [::1]:34788 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34792 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34792 [200]: GET /styles.css
-[Thu Feb 19 00:36:01 2026] [::1]:34792 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34796 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34796 [200]: GET /admin.css
-[Thu Feb 19 00:36:01 2026] [::1]:34796 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34798 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34798 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:36:01 2026] [::1]:34798 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34806 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34806 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:36:01 2026] [::1]:34806 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34820 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34820 [200]: GET /
-[Thu Feb 19 00:36:01 2026] [::1]:34820 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34826 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34832 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34826 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:01 2026] [::1]:34838 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34832 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:01 2026] [::1]:34838 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:01 2026] [::1]:34826 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34832 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34838 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34850 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34850 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:01 2026] [::1]:34850 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34866 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34866 [429]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:36:01 2026] [::1]:34866 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34878 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34884 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34890 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34902 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34878 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:01 2026] [::1]:34884 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:01 2026] [::1]:34890 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:01 2026] [::1]:34902 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:01 2026] [::1]:34878 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34884 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34890 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34902 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34906 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34906 [200]: GET /
-[Thu Feb 19 00:36:01 2026] [::1]:34906 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34910 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34916 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34910 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:01 2026] [::1]:34916 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:01 2026] [::1]:34928 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34910 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34916 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34928 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:01 2026] [::1]:34928 Closing
-[Thu Feb 19 00:36:01 2026] [::1]:34936 Accepted
-[Thu Feb 19 00:36:01 2026] [::1]:34936 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:01 2026] [::1]:34936 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:34946 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:34958 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:34946 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:02 2026] [::1]:34964 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:34958 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:02 2026] [::1]:34980 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:34964 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:02 2026] [::1]:34946 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:34980 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:02 2026] [::1]:34958 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:34964 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:34980 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:34992 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:34992 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:02 2026] [::1]:34992 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:34998 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35002 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35016 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35028 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35030 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:34998 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:02 2026] [::1]:35002 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:02 2026] [::1]:34998 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35002 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35040 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35016 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:02 2026] [::1]:35016 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35028 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:02 2026] [::1]:35030 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:02 2026] [::1]:35028 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35030 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35040 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:02 2026] [::1]:35040 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35050 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35060 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35050 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:02 2026] [::1]:35060 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:02 2026] [::1]:35050 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35060 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35074 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35074 [200]: GET /
-[Thu Feb 19 00:36:02 2026] [::1]:35074 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35084 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35100 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35114 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35084 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:02 2026] [::1]:35084 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35100 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:02 2026] [::1]:35100 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35114 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:02 2026] [::1]:35114 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35118 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35118 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:02 2026] [::1]:35118 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35126 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35140 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35146 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35158 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35126 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:02 2026] [::1]:35140 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:02 2026] [::1]:35146 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:02 2026] [::1]:35158 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:02 2026] [::1]:35126 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35140 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35146 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35158 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35170 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35170 [200]: GET /
-[Thu Feb 19 00:36:02 2026] [::1]:35170 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35176 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35176 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:02 2026] [::1]:35176 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35186 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35194 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35196 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35186 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:02 2026] [::1]:35194 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:02 2026] [::1]:35196 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:02 2026] [::1]:35186 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35194 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35196 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35202 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35202 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:02 2026] [::1]:35202 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35208 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35218 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35208 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:02 2026] [::1]:35232 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35218 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:02 2026] [::1]:35240 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35232 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:02 2026] [::1]:35208 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35240 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:02 2026] [::1]:35218 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35232 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35240 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35254 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35266 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35270 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35282 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35298 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35302 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35254 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:02 2026] [::1]:35266 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:02 2026] [::1]:35270 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:02 2026] [::1]:35254 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35266 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35270 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35282 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:02 2026] [::1]:35282 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35298 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:02 2026] [::1]:35298 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35302 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:02 2026] [::1]:35302 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35318 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35318 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:02 2026] [::1]:35318 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35326 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35330 Accepted
-[Thu Feb 19 00:36:02 2026] [::1]:35326 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:02 2026] [::1]:35326 Closing
-[Thu Feb 19 00:36:02 2026] [::1]:35330 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:02 2026] [::1]:35330 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35334 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35334 [200]: GET /
-[Thu Feb 19 00:36:03 2026] [::1]:35334 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35338 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35350 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35362 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35338 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:03 2026] [::1]:35338 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35350 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:03 2026] [::1]:35362 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:03 2026] [::1]:35350 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35362 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35372 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35372 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:03 2026] [::1]:35372 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35382 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35382 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:03 2026] [::1]:35382 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35384 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35388 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35392 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35384 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:03 2026] [::1]:35388 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:03 2026] [::1]:35392 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:03 2026] [::1]:35384 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35388 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35392 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35406 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35420 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35406 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:03 2026] [::1]:35426 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35420 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:03 2026] [::1]:35430 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35426 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:03 2026] [::1]:35432 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35406 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35430 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:03 2026] [::1]:35420 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35432 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:03 2026] [::1]:35426 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35430 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35432 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35446 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35446 [200]: GET /
-[Thu Feb 19 00:36:03 2026] [::1]:35446 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35448 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35462 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35474 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35476 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35448 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:03 2026] [::1]:35448 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35462 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:03 2026] [::1]:35462 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35474 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:03 2026] [::1]:35474 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35476 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:03 2026] [::1]:35476 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35484 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35494 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35484 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:03 2026] [::1]:35502 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35494 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:03 2026] [::1]:35502 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:03 2026] [::1]:35484 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35494 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35502 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35508 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35508 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:03 2026] [::1]:35508 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35522 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35536 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35522 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:03 2026] [::1]:35542 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35536 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:03 2026] [::1]:35552 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35542 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:03 2026] [::1]:35522 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35552 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:03 2026] [::1]:35536 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35542 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35552 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35558 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35558 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:03 2026] [::1]:35558 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35560 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35562 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35560 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:03 2026] [::1]:35574 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35562 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:03 2026] [::1]:35580 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35574 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:03 2026] [::1]:35560 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35580 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:03 2026] [::1]:35562 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35574 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35580 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35588 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35604 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35588 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:03 2026] [::1]:35604 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:03 2026] [::1]:35588 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35604 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35610 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35610 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:03 2026] [::1]:35610 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35624 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35624 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:03 2026] [::1]:35624 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35636 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35636 [200]: GET /
-[Thu Feb 19 00:36:03 2026] [::1]:35636 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35650 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35658 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35674 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35650 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:03 2026] [::1]:35650 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35658 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:03 2026] [::1]:35674 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:03 2026] [::1]:35658 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35674 Closing
-[Thu Feb 19 00:36:03 2026] [::1]:35688 Accepted
-[Thu Feb 19 00:36:03 2026] [::1]:35688 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:03 2026] [::1]:35688 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35704 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35720 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35732 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35746 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35704 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35704 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35720 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35720 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35732 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35732 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35746 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35746 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35754 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35754 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:04 2026] [::1]:35754 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35760 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35762 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35760 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:04 2026] [::1]:35762 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:04 2026] [::1]:35760 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35762 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35776 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35776 [200]: GET /
-[Thu Feb 19 00:36:04 2026] [::1]:35776 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35778 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35792 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35778 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:04 2026] [::1]:35808 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35778 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35792 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:04 2026] [::1]:35792 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35808 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:04 2026] [::1]:35808 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35810 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35810 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:04 2026] [::1]:35810 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35816 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35832 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35816 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35834 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35832 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35840 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35834 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35816 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35840 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35832 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35834 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35840 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35846 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35846 [200]: GET /
-[Thu Feb 19 00:36:04 2026] [::1]:35846 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35862 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35866 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35862 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:04 2026] [::1]:35866 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:04 2026] [::1]:35862 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35866 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35868 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35868 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:04 2026] [::1]:35868 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35880 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35880 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:04 2026] [::1]:35880 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35882 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35888 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35902 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35906 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35882 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35888 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35902 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35882 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35888 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35902 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35906 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:04 2026] [::1]:35906 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35914 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35914 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:04 2026] [::1]:35914 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35920 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35932 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35936 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35952 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35968 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35920 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:04 2026] [::1]:35932 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:04 2026] [::1]:35920 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35932 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35936 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:04 2026] [::1]:35936 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35972 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35952 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:04 2026] [::1]:35952 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35968 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:04 2026] [::1]:35968 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35972 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:04 2026] [::1]:35972 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35974 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35986 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35974 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:04 2026] [::1]:35986 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:04 2026] [::1]:35974 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35986 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:35996 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:35996 [200]: GET /
-[Thu Feb 19 00:36:04 2026] [::1]:35996 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:36006 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:36010 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:36018 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:36006 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:04 2026] [::1]:36010 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:04 2026] [::1]:36018 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:04 2026] [::1]:36006 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:36010 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:36018 Closing
-[Thu Feb 19 00:36:04 2026] [::1]:36034 Accepted
-[Thu Feb 19 00:36:04 2026] [::1]:36034 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:04 2026] [::1]:36034 Closing
-[Thu Feb 19 00:36:18 2026] [::1]:55106 Accepted
-[Thu Feb 19 00:36:18 2026] [::1]:55106 [200]: GET /index.html
-[Thu Feb 19 00:36:18 2026] [::1]:55106 Closing
-[Thu Feb 19 00:36:18 2026] [::1]:55116 Accepted
-[Thu Feb 19 00:36:18 2026] [::1]:55124 Accepted
-[Thu Feb 19 00:36:18 2026] [::1]:55136 Accepted
-[Thu Feb 19 00:36:18 2026] [::1]:55116 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:18 2026] [::1]:55116 Closing
-[Thu Feb 19 00:36:18 2026] [::1]:55124 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:18 2026] [::1]:55124 Closing
-[Thu Feb 19 00:36:18 2026] [::1]:55136 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:18 2026] [::1]:55136 Closing
-[Thu Feb 19 00:36:18 2026] [::1]:55148 Accepted
-[Thu Feb 19 00:36:18 2026] [::1]:55148 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:18 2026] [::1]:55148 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55158 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55166 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55174 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55186 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55158 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:20 2026] [::1]:55166 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:20 2026] [::1]:55174 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:20 2026] [::1]:55186 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:20 2026] [::1]:55158 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55166 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55174 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55186 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55198 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55198 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:20 2026] [::1]:55198 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55204 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55212 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55226 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55236 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55242 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55204 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:20 2026] [::1]:55212 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:20 2026] [::1]:55226 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:20 2026] [::1]:55236 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:20 2026] [::1]:55204 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55212 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55254 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55226 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55236 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55242 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:20 2026] [::1]:55242 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55254 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:20 2026] [::1]:55254 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55256 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55268 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55256 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:20 2026] [::1]:55268 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:20 2026] [::1]:55256 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55268 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55274 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55274 [200]: GET /index.html
-[Thu Feb 19 00:36:20 2026] [::1]:55274 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55280 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55296 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55310 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55280 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:20 2026] [::1]:55280 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55296 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:20 2026] [::1]:55296 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55310 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:20 2026] [::1]:55310 Closing
-[Thu Feb 19 00:36:20 2026] [::1]:55320 Accepted
-[Thu Feb 19 00:36:20 2026] [::1]:55320 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:20 2026] [::1]:55320 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55334 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55346 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55356 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55360 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55334 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:23 2026] [::1]:55346 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:23 2026] [::1]:55356 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:23 2026] [::1]:55334 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55346 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55356 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55360 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:23 2026] [::1]:55360 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55364 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55370 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55364 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:23 2026] [::1]:55378 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55370 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:23 2026] [::1]:55378 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:23 2026] [::1]:55364 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55370 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55378 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55386 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55402 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55408 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55418 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55420 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55386 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:23 2026] [::1]:55402 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:23 2026] [::1]:55386 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55402 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55422 Accepted
-[Thu Feb 19 00:36:23 2026] [::1]:55408 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:23 2026] [::1]:55418 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:23 2026] [::1]:55408 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55418 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55420 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:23 2026] [::1]:55420 Closing
-[Thu Feb 19 00:36:23 2026] [::1]:55422 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:23 2026] [::1]:55422 Closing
-[Thu Feb 19 00:36:35 2026] [::1]:40778 Accepted
-[Thu Feb 19 00:36:35 2026] [::1]:40778 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:36:35 2026] [::1]:40778 Closing
-[Thu Feb 19 00:36:35 2026] [::1]:40794 Accepted
-[Thu Feb 19 00:36:35 2026] [::1]:40794 [200]: GET /api.php?resource=booked-slots&date=2026-02-21&doctor=rosero
-[Thu Feb 19 00:36:35 2026] [::1]:40794 Closing
-[Thu Feb 19 00:36:35 2026] [::1]:40802 Accepted
-[Thu Feb 19 00:36:35 2026] [::1]:40810 Accepted
-[Thu Feb 19 00:36:35 2026] [::1]:40820 Accepted
-[Thu Feb 19 00:36:35 2026] [::1]:40834 Accepted
-[Thu Feb 19 00:36:35 2026] [::1]:40838 Accepted
-[Thu Feb 19 00:36:35 2026] [::1]:40802 [200]: GET /images/optimized/service-consulta.avif
-[Thu Feb 19 00:36:35 2026] [::1]:40810 [200]: GET /images/optimized/service-telemedicina.avif
-[Thu Feb 19 00:36:35 2026] [::1]:40820 [200]: GET /images/optimized/service-laser.avif
-[Thu Feb 19 00:36:35 2026] [::1]:40834 [200]: GET /images/optimized/service-rejuvenecimiento.avif
-[Thu Feb 19 00:36:35 2026] [::1]:40848 Accepted
-[Thu Feb 19 00:36:35 2026] [::1]:40838 [200]: GET /images/optimized/service-acne.avif
-[Thu Feb 19 00:36:35 2026] [::1]:40848 [200]: GET /images/optimized/service-cancer.avif
-[Thu Feb 19 00:36:35 2026] [::1]:40802 Closing
-[Thu Feb 19 00:36:35 2026] [::1]:40810 Closing
-[Thu Feb 19 00:36:35 2026] [::1]:40820 Closing
-[Thu Feb 19 00:36:35 2026] [::1]:40834 Closing
-[Thu Feb 19 00:36:35 2026] [::1]:40838 Closing
-[Thu Feb 19 00:36:35 2026] [::1]:40848 Closing
-[Thu Feb 19 00:36:36 2026] [::1]:40850 Accepted
-[Thu Feb 19 00:36:36 2026] [::1]:40860 Accepted
-[Thu Feb 19 00:36:36 2026] [::1]:40850 [200]: GET /images/optimized/team-rosero.avif
-[Thu Feb 19 00:36:36 2026] [::1]:40850 Closing
-[Thu Feb 19 00:36:36 2026] [::1]:40860 [200]: GET /images/optimized/team-narvaez.avif
-[Thu Feb 19 00:36:36 2026] [::1]:40860 Closing
-[Thu Feb 19 00:36:36 2026] [::1]:40864 Accepted
-[Thu Feb 19 00:36:36 2026] [::1]:40864 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:36:36 2026] [::1]:40864 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49538 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49538 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:36:37 2026] [::1]:49538 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49554 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49554 [200]: GET /index.html
-[Thu Feb 19 00:36:37 2026] [::1]:49554 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49564 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49568 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49570 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49564 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:37 2026] [::1]:49564 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49568 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:37 2026] [::1]:49570 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:37 2026] [::1]:49568 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49570 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49582 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49582 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:37 2026] [::1]:49582 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49590 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49602 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49590 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:37 2026] [::1]:49602 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:37 2026] [::1]:49590 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49602 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49616 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49632 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49616 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:37 2026] [::1]:49616 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49632 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:37 2026] [::1]:49632 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49634 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49634 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:37 2026] [::1]:49634 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49642 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49642 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:37 2026] [::1]:49642 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49646 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49646 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:37 2026] [::1]:49646 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49658 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49660 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49670 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49678 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49688 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49658 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:37 2026] [::1]:49658 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49660 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:37 2026] [::1]:49660 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49670 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:37 2026] [::1]:49670 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49678 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:37 2026] [::1]:49688 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:37 2026] [::1]:49678 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49688 Closing
-[Thu Feb 19 00:36:37 2026] [::1]:49690 Accepted
-[Thu Feb 19 00:36:37 2026] [::1]:49690 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:37 2026] [::1]:49690 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49698 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49698 [200]: GET /index.html
-[Thu Feb 19 00:36:38 2026] [::1]:49698 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49706 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49706 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:38 2026] [::1]:49706 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49718 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49730 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49718 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:38 2026] [::1]:49718 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49730 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:38 2026] [::1]:49730 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49734 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49734 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:38 2026] [::1]:49734 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49738 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49748 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49760 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49770 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49738 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:38 2026] [::1]:49748 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:38 2026] [::1]:49760 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:38 2026] [::1]:49770 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:38 2026] [::1]:49738 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49748 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49760 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49770 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49776 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49776 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:36:38 2026] [::1]:49776 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49792 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49792 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:38 2026] [::1]:49792 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49800 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49808 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49822 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49834 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49838 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49852 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49800 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:38 2026] [::1]:49808 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:38 2026] [::1]:49822 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:38 2026] [::1]:49800 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49808 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49822 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49834 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:38 2026] [::1]:49834 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49838 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:38 2026] [::1]:49838 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49852 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:38 2026] [::1]:49852 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49860 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49872 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49860 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:38 2026] [::1]:49872 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:38 2026] [::1]:49860 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49872 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49888 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49888 [200]: GET /figo-chat.php
-[Thu Feb 19 00:36:38 2026] [::1]:49888 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49890 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49890 [404]: GET /data/ - No such file or directory
-[Thu Feb 19 00:36:38 2026] [::1]:49890 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49896 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49896 [404]: GET /uploads/ - No such file or directory
-[Thu Feb 19 00:36:38 2026] [::1]:49896 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49900 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49900 [200]: GET /
-[Thu Feb 19 00:36:38 2026] [::1]:49900 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49908 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49922 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49930 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49908 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:38 2026] [::1]:49908 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49922 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:38 2026] [::1]:49922 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49930 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:38 2026] [::1]:49930 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49938 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49938 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:38 2026] [::1]:49938 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49942 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49954 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49956 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49966 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49942 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:38 2026] [::1]:49954 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:38 2026] [::1]:49956 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:38 2026] [::1]:49966 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:38 2026] [::1]:49942 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49954 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49956 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49966 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49980 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49980 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:38 2026] [::1]:49980 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:49986 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:49986 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:38 2026] [::1]:49986 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:50002 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:50016 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:50026 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:50032 Accepted
-[Thu Feb 19 00:36:38 2026] [::1]:50002 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:38 2026] [::1]:50016 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:38 2026] [::1]:50002 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:50026 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:38 2026] [::1]:50016 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:50026 Closing
-[Thu Feb 19 00:36:38 2026] [::1]:50032 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:38 2026] [::1]:50032 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50040 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50046 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50040 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:39 2026] [::1]:50058 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50046 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:39 2026] [::1]:50058 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:39 2026] [::1]:50040 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50046 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50058 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50068 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50068 [200]: GET /
-[Thu Feb 19 00:36:39 2026] [::1]:50068 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50084 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50096 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50100 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50084 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:39 2026] [::1]:50096 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:39 2026] [::1]:50100 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:39 2026] [::1]:50084 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50096 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50100 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50112 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50112 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:39 2026] [::1]:50112 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50124 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50140 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50146 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50148 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50124 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:39 2026] [::1]:50140 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:39 2026] [::1]:50146 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:39 2026] [::1]:50124 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50140 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50146 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50148 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:39 2026] [::1]:50148 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50162 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50170 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50172 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50188 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50200 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50206 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50162 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:39 2026] [::1]:50162 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50170 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:39 2026] [::1]:50170 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50172 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:39 2026] [::1]:50172 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50188 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:39 2026] [::1]:50188 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50200 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:39 2026] [::1]:50200 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50206 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:39 2026] [::1]:50206 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50222 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50238 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50222 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:39 2026] [::1]:50222 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50238 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:39 2026] [::1]:50238 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50242 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50242 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:39 2026] [::1]:50242 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50258 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50258 [200]: GET /
-[Thu Feb 19 00:36:39 2026] [::1]:50258 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50272 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50274 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50272 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:39 2026] [::1]:50280 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50272 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50274 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:39 2026] [::1]:50280 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:39 2026] [::1]:50274 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50280 Closing
-[Thu Feb 19 00:36:39 2026] [::1]:50286 Accepted
-[Thu Feb 19 00:36:39 2026] [::1]:50286 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:39 2026] [::1]:50286 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50296 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50304 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50306 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50316 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50296 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50304 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50306 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50316 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50296 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50304 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50306 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50316 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50320 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50328 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50320 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:40 2026] [::1]:50328 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:40 2026] [::1]:50320 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50328 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50338 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50338 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:40 2026] [::1]:50338 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50350 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50350 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:40 2026] [::1]:50350 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50352 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50360 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50364 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50368 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50378 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50352 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:40 2026] [::1]:50352 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50360 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:40 2026] [::1]:50360 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50364 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:40 2026] [::1]:50364 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50368 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:40 2026] [::1]:50378 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:40 2026] [::1]:50368 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50378 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50390 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50396 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50390 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50408 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50416 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50390 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50396 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50396 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50426 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50408 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50408 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50426 [200]: GET /
-[Thu Feb 19 00:36:40 2026] [::1]:50426 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50416 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50416 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50430 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50440 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50454 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50430 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:40 2026] [::1]:50430 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50440 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:40 2026] [::1]:50440 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50456 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50454 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:40 2026] [::1]:50454 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50456 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:40 2026] [::1]:50456 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50472 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50476 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50492 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50498 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50500 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50516 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50472 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:40 2026] [::1]:50476 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:40 2026] [::1]:50492 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:40 2026] [::1]:50498 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:40 2026] [::1]:50500 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:40 2026] [::1]:50516 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:40 2026] [::1]:50472 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50476 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50492 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50498 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50500 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50516 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50530 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50530 [200]: GET /
-[Thu Feb 19 00:36:40 2026] [::1]:50530 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50532 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50532 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:40 2026] [::1]:50532 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50540 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50540 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:40 2026] [::1]:50540 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50548 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50548 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:40 2026] [::1]:50548 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50562 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50562 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:40 2026] [::1]:50562 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50568 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50582 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50592 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50596 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50568 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50568 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50582 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50582 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50592 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50592 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50596 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:40 2026] [::1]:50596 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50606 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50620 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50606 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:40 2026] [::1]:50620 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:40 2026] [::1]:50606 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50620 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50630 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50646 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50630 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:40 2026] [::1]:50654 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50646 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:40 2026] [::1]:50662 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50654 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:40 2026] [::1]:50668 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50630 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50662 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:40 2026] [::1]:50672 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50646 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50668 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:40 2026] [::1]:50672 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:40 2026] [::1]:50654 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50662 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50668 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50672 Closing
-[Thu Feb 19 00:36:40 2026] [::1]:50682 Accepted
-[Thu Feb 19 00:36:40 2026] [::1]:50682 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:40 2026] [::1]:50682 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50694 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50694 [200]: GET /
-[Thu Feb 19 00:36:41 2026] [::1]:50694 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50710 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50716 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50710 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:41 2026] [::1]:50716 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:41 2026] [::1]:50710 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50716 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50720 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50720 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:41 2026] [::1]:50720 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50726 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50726 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:41 2026] [::1]:50726 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50738 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50738 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:41 2026] [::1]:50738 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50754 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50764 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50754 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:41 2026] [::1]:50764 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:41 2026] [::1]:50754 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50764 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50766 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50766 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:41 2026] [::1]:50766 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50782 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50782 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:41 2026] [::1]:50782 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50792 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50796 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50812 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50820 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50792 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:41 2026] [::1]:50796 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:41 2026] [::1]:50812 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:41 2026] [::1]:50820 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:41 2026] [::1]:50792 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50796 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50812 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50820 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50822 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50822 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:41 2026] [::1]:50822 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50832 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50836 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50832 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:41 2026] [::1]:50846 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50836 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:41 2026] [::1]:50846 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:41 2026] [::1]:50832 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50836 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50846 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50856 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50856 [200]: GET /
-[Thu Feb 19 00:36:41 2026] [::1]:50856 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50872 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50880 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50872 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:41 2026] [::1]:50880 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:41 2026] [::1]:50872 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50880 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50886 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50886 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:41 2026] [::1]:50886 Closing
-[Thu Feb 19 00:36:41 2026] [::1]:50902 Accepted
-[Thu Feb 19 00:36:41 2026] [::1]:50902 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:41 2026] [::1]:50902 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:50912 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:50920 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:50912 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:42 2026] [::1]:50920 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:42 2026] [::1]:50912 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:50920 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:50936 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:50952 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:50936 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:42 2026] [::1]:50952 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:42 2026] [::1]:50936 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:50952 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:50960 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:50960 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:42 2026] [::1]:50960 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:50970 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:50986 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:50970 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:42 2026] [::1]:50970 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:50986 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:42 2026] [::1]:50986 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:50990 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51006 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51016 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:50990 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:42 2026] [::1]:50990 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51006 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:42 2026] [::1]:51016 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:42 2026] [::1]:51006 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51016 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51024 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51026 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51036 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51024 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:42 2026] [::1]:51024 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51026 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:42 2026] [::1]:51026 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51036 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:42 2026] [::1]:51036 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51046 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51046 [200]: GET /
-[Thu Feb 19 00:36:42 2026] [::1]:51046 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51054 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51054 [200]: GET /
-[Thu Feb 19 00:36:42 2026] [::1]:51054 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51062 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51062 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:42 2026] [::1]:51062 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51066 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51070 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51066 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:42 2026] [::1]:51066 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51076 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51076 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:42 2026] [::1]:51076 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51070 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:42 2026] [::1]:51070 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51088 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51096 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51088 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:42 2026] [::1]:51088 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51098 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51098 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:42 2026] [::1]:51098 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51096 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:42 2026] [::1]:51096 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51114 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51114 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:42 2026] [::1]:51114 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51116 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51122 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51130 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51142 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51116 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51116 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51122 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51122 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51130 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51130 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51142 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51142 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51146 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51152 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51168 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51180 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51146 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51152 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51168 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51146 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51152 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51168 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51180 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51180 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51192 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51192 [200]: GET /
-[Thu Feb 19 00:36:42 2026] [::1]:51192 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51200 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51204 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51200 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:42 2026] [::1]:51204 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:42 2026] [::1]:51200 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51204 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51206 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51206 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:42 2026] [::1]:51206 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51214 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51214 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:42 2026] [::1]:51214 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51222 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51222 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51222 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51234 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51234 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51234 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51240 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51242 Accepted
-[Thu Feb 19 00:36:42 2026] [::1]:51240 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51242 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:42 2026] [::1]:51240 Closing
-[Thu Feb 19 00:36:42 2026] [::1]:51242 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51248 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51254 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51270 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51278 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51290 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51300 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51248 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:43 2026] [::1]:51248 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51254 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:43 2026] [::1]:51254 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51270 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:43 2026] [::1]:51270 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51278 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:43 2026] [::1]:51278 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51290 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:43 2026] [::1]:51290 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51300 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:43 2026] [::1]:51300 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51308 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51324 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51308 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:43 2026] [::1]:51334 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51324 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:43 2026] [::1]:51334 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:43 2026] [::1]:51308 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51324 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51334 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51338 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51338 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:43 2026] [::1]:51338 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51346 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51346 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:43 2026] [::1]:51346 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51348 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51348 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:43 2026] [::1]:51348 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51362 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51362 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:43 2026] [::1]:51362 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51376 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51376 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:43 2026] [::1]:51376 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51382 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51382 [200]: GET /
-[Thu Feb 19 00:36:43 2026] [::1]:51382 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51384 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51384 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:43 2026] [::1]:51384 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51386 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51386 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:43 2026] [::1]:51386 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51400 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51400 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:43 2026] [::1]:51400 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51406 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51406 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:43 2026] [::1]:51406 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51416 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51422 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51428 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51434 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51416 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:43 2026] [::1]:51422 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:43 2026] [::1]:51428 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:43 2026] [::1]:51434 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:43 2026] [::1]:51416 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51422 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51428 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51434 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51442 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51452 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51466 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51476 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51442 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:43 2026] [::1]:51452 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:43 2026] [::1]:51466 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:43 2026] [::1]:51476 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:43 2026] [::1]:51442 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51452 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51466 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51476 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51480 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51492 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51480 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:43 2026] [::1]:51492 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:43 2026] [::1]:51480 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51492 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51506 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51506 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:43 2026] [::1]:51506 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51516 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51518 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51530 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51546 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51516 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:43 2026] [::1]:51518 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:43 2026] [::1]:51530 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:43 2026] [::1]:51546 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:43 2026] [::1]:51516 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51518 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51530 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51546 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51550 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51550 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:43 2026] [::1]:51550 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51566 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51566 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:43 2026] [::1]:51566 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51580 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51580 [200]: GET /terminos.html
-[Thu Feb 19 00:36:43 2026] [::1]:51580 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51582 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51590 Accepted
-[Thu Feb 19 00:36:43 2026] [::1]:51582 [200]: GET /legal.css
-[Thu Feb 19 00:36:43 2026] [::1]:51590 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:43 2026] [::1]:51582 Closing
-[Thu Feb 19 00:36:43 2026] [::1]:51590 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51604 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51604 [200]: GET /terminos.html
-[Thu Feb 19 00:36:44 2026] [::1]:51604 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51620 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51636 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51620 [200]: GET /legal.css
-[Thu Feb 19 00:36:44 2026] [::1]:51636 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:44 2026] [::1]:51620 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51636 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51642 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51642 [200]: GET /terminos.html
-[Thu Feb 19 00:36:44 2026] [::1]:51642 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51652 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51652 [200]: GET /legal.css
-[Thu Feb 19 00:36:44 2026] [::1]:51652 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51664 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51664 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:44 2026] [::1]:51664 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51668 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51668 [200]: GET /terminos.html
-[Thu Feb 19 00:36:44 2026] [::1]:51668 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51676 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51686 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51676 [200]: GET /legal.css
-[Thu Feb 19 00:36:44 2026] [::1]:51676 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51686 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:44 2026] [::1]:51686 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51690 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51690 [200]: GET /privacidad.html
-[Thu Feb 19 00:36:44 2026] [::1]:51690 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51696 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51704 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51696 [200]: GET /legal.css
-[Thu Feb 19 00:36:44 2026] [::1]:51704 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:44 2026] [::1]:51696 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51704 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51718 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51718 [200]: GET /privacidad.html
-[Thu Feb 19 00:36:44 2026] [::1]:51718 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51728 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51742 Accepted
-[Thu Feb 19 00:36:44 2026] [::1]:51728 [200]: GET /legal.css
-[Thu Feb 19 00:36:44 2026] [::1]:51742 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:44 2026] [::1]:51728 Closing
-[Thu Feb 19 00:36:44 2026] [::1]:51742 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51750 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51750 [200]: GET /privacidad.html
-[Thu Feb 19 00:36:45 2026] [::1]:51750 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51758 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51760 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51758 [200]: GET /legal.css
-[Thu Feb 19 00:36:45 2026] [::1]:51758 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51760 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:45 2026] [::1]:51760 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51770 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51770 [200]: GET /?reschedule=token_invalido_123
-[Thu Feb 19 00:36:45 2026] [::1]:51770 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51772 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51776 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51790 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51772 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:45 2026] [::1]:51776 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:45 2026] [::1]:51790 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:45 2026] [::1]:51772 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51776 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51790 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51792 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51792 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:45 2026] [::1]:51792 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51798 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51798 [200]: GET /privacidad.html
-[Thu Feb 19 00:36:45 2026] [::1]:51798 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51800 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51808 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51800 [200]: GET /legal.css
-[Thu Feb 19 00:36:45 2026] [::1]:51808 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:45 2026] [::1]:51800 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51808 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51816 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51826 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51838 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51846 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51816 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:45 2026] [::1]:51816 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51826 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:45 2026] [::1]:51826 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51838 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:45 2026] [::1]:51838 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51846 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:45 2026] [::1]:51846 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51852 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51852 [200]: GET /reschedule-engine.js?v=figo-reschedule-20260218-phase4
-[Thu Feb 19 00:36:45 2026] [::1]:51852 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51858 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51858 [404]: GET /api.php?resource=reschedule&token=token_invalido_123
-[Thu Feb 19 00:36:45 2026] [::1]:51858 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51868 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51868 [200]: GET /cookies.html
-[Thu Feb 19 00:36:45 2026] [::1]:51868 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51880 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51892 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51908 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51880 [200]: GET /legal.css
-[Thu Feb 19 00:36:45 2026] [::1]:51892 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:45 2026] [::1]:51908 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:45 2026] [::1]:51880 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51892 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51908 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51918 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51918 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:45 2026] [::1]:51918 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51934 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51934 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:45 2026] [::1]:51934 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51940 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51942 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51940 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:45 2026] [::1]:51950 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51942 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:45 2026] [::1]:51958 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51950 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:45 2026] [::1]:51968 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51940 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51942 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51950 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51978 Accepted
-[Thu Feb 19 00:36:45 2026] [::1]:51958 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:45 2026] [::1]:51958 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51968 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:45 2026] [::1]:51968 Closing
-[Thu Feb 19 00:36:45 2026] [::1]:51978 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:45 2026] [::1]:51978 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:51988 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:51988 [200]: GET /cookies.html
-[Thu Feb 19 00:36:46 2026] [::1]:51988 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52000 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52002 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52000 [200]: GET /legal.css
-[Thu Feb 19 00:36:46 2026] [::1]:52002 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:46 2026] [::1]:52000 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52002 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52012 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52012 [200]: GET /cookies.html
-[Thu Feb 19 00:36:46 2026] [::1]:52012 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52020 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52028 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52020 [200]: GET /legal.css
-[Thu Feb 19 00:36:46 2026] [::1]:52020 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52028 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:46 2026] [::1]:52028 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52044 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52044 [200]: GET /cookies.html
-[Thu Feb 19 00:36:46 2026] [::1]:52044 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52060 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52074 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52060 [200]: GET /legal.css
-[Thu Feb 19 00:36:46 2026] [::1]:52060 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52074 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:46 2026] [::1]:52074 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52078 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52078 [200]: GET /aviso-medico.html
-[Thu Feb 19 00:36:46 2026] [::1]:52078 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52094 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52106 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52094 [200]: GET /legal.css
-[Thu Feb 19 00:36:46 2026] [::1]:52106 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:46 2026] [::1]:52094 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52106 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52110 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52110 [200]: GET /aviso-medico.html
-[Thu Feb 19 00:36:46 2026] [::1]:52110 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52122 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52124 Accepted
-[Thu Feb 19 00:36:46 2026] [::1]:52122 [200]: GET /legal.css
-[Thu Feb 19 00:36:46 2026] [::1]:52124 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:46 2026] [::1]:52122 Closing
-[Thu Feb 19 00:36:46 2026] [::1]:52124 Closing
-[Thu Feb 19 00:36:47 2026] [::1]:35880 Accepted
-[Thu Feb 19 00:36:47 2026] [::1]:35880 [200]: GET /aviso-medico.html
-[Thu Feb 19 00:36:47 2026] [::1]:35880 Closing
-[Thu Feb 19 00:36:47 2026] [::1]:35884 Accepted
-[Thu Feb 19 00:36:47 2026] [::1]:35886 Accepted
-[Thu Feb 19 00:36:47 2026] [::1]:35884 [200]: GET /legal.css
-[Thu Feb 19 00:36:47 2026] [::1]:35886 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:47 2026] [::1]:35884 Closing
-[Thu Feb 19 00:36:47 2026] [::1]:35886 Closing
-[Thu Feb 19 00:36:47 2026] [::1]:35898 Accepted
-[Thu Feb 19 00:36:47 2026] [::1]:35898 [200]: GET /aviso-medico.html
-[Thu Feb 19 00:36:47 2026] [::1]:35898 Closing
-[Thu Feb 19 00:36:47 2026] [::1]:35900 Accepted
-[Thu Feb 19 00:36:47 2026] [::1]:35900 [200]: GET /legal.css
-[Thu Feb 19 00:36:47 2026] [::1]:35900 Closing
-[Thu Feb 19 00:36:47 2026] [::1]:35910 Accepted
-[Thu Feb 19 00:36:47 2026] [::1]:35910 [200]: GET /legal-i18n.js
-[Thu Feb 19 00:36:47 2026] [::1]:35910 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35918 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35918 [200]: GET /
-[Thu Feb 19 00:36:48 2026] [::1]:35918 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35926 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35930 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35934 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35926 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:36:48 2026] [::1]:35926 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35930 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:36:48 2026] [::1]:35934 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:36:48 2026] [::1]:35930 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35934 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35946 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35946 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:36:48 2026] [::1]:35946 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35958 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35964 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35970 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35976 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35958 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:36:48 2026] [::1]:35964 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:36:48 2026] [::1]:35970 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:36:48 2026] [::1]:35976 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:36:48 2026] [::1]:35958 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35964 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35970 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35976 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35982 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35982 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:36:48 2026] [::1]:35982 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35988 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35992 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35998 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:36008 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:36016 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:36022 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:35988 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:36:48 2026] [::1]:35988 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35992 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:36:48 2026] [::1]:35992 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:35998 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:36:48 2026] [::1]:35998 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:36008 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:36:48 2026] [::1]:36008 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:36016 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:36:48 2026] [::1]:36016 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:36022 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:36:48 2026] [::1]:36022 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:36038 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:36054 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:36038 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:36:48 2026] [::1]:36054 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:36:48 2026] [::1]:36038 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:36054 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:36070 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:36070 [400]: GET /api.php?resource=reschedule&token=
-[Thu Feb 19 00:36:48 2026] [::1]:36070 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:36082 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:36082 [404]: GET /api.php?resource=reschedule&token=abcdef1234567890abcdef1234567890
-[Thu Feb 19 00:36:48 2026] [::1]:36082 Closing
-[Thu Feb 19 00:36:48 2026] [::1]:36088 Accepted
-[Thu Feb 19 00:36:48 2026] [::1]:36088 [400]: PATCH /api.php?resource=reschedule
-[Thu Feb 19 00:36:48 2026] [::1]:36088 Closing
-[Thu Feb 19 00:37:03 2026] [::1]:35342 Accepted
-[Thu Feb 19 00:37:03 2026] [::1]:35342 [200]: GET /api.php?resource=health
-[Thu Feb 19 00:37:03 2026] [::1]:35342 Closing
-[Thu Feb 19 00:37:03 2026] [::1]:35354 Accepted
-[Thu Feb 19 00:37:03 2026] [::1]:35354 [200]: GET /admin.html
-[Thu Feb 19 00:37:03 2026] [::1]:35354 Closing
-[Thu Feb 19 00:37:03 2026] [::1]:35370 Accepted
-[Thu Feb 19 00:37:03 2026] [::1]:35382 Accepted
-[Thu Feb 19 00:37:03 2026] [::1]:35370 [200]: GET /styles.css
-[Thu Feb 19 00:37:03 2026] [::1]:35370 Closing
-[Thu Feb 19 00:37:03 2026] [::1]:35382 [200]: GET /admin.css
-[Thu Feb 19 00:37:03 2026] [::1]:35382 Closing
-[Thu Feb 19 00:37:03 2026] [::1]:35398 Accepted
-[Thu Feb 19 00:37:03 2026] [::1]:35398 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:37:03 2026] [::1]:35398 Closing
-[Thu Feb 19 00:37:03 2026] [::1]:35406 Accepted
-[Thu Feb 19 00:37:03 2026] [::1]:35406 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:37:03 2026] [::1]:35406 Closing
-[Thu Feb 19 00:37:04 2026] [::1]:35414 Accepted
-[Thu Feb 19 00:37:04 2026] [::1]:35414 [401]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:37:04 2026] [::1]:35414 Closing
-[Thu Feb 19 00:37:04 2026] [::1]:35426 Accepted
-[Thu Feb 19 00:37:04 2026] [::1]:35426 [200]: GET /admin.html
-[Thu Feb 19 00:37:04 2026] [::1]:35426 Closing
-[Thu Feb 19 00:37:04 2026] [::1]:35428 Accepted
-[Thu Feb 19 00:37:04 2026] [::1]:35440 Accepted
-[Thu Feb 19 00:37:04 2026] [::1]:35428 [200]: GET /styles.css
-[Thu Feb 19 00:37:04 2026] [::1]:35428 Closing
-[Thu Feb 19 00:37:04 2026] [::1]:35440 [200]: GET /admin.css
-[Thu Feb 19 00:37:04 2026] [::1]:35440 Closing
-[Thu Feb 19 00:37:04 2026] [::1]:35448 Accepted
-[Thu Feb 19 00:37:04 2026] [::1]:35448 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1
-[Thu Feb 19 00:37:04 2026] [::1]:35448 Closing
-[Thu Feb 19 00:37:04 2026] [::1]:35462 Accepted
-[Thu Feb 19 00:37:04 2026] [::1]:35462 [200]: GET /admin-auth.php?action=status
-[Thu Feb 19 00:37:04 2026] [::1]:35462 Closing
-[Thu Feb 19 00:37:04 2026] [::1]:35478 Accepted
-[Thu Feb 19 00:37:04 2026] [::1]:35478 [200]: POST /admin-auth.php?action=login
-[Thu Feb 19 00:37:04 2026] [::1]:35478 Closing
-[Thu Feb 19 00:37:04 2026] [::1]:35492 Accepted
-[Thu Feb 19 00:37:04 2026] [::1]:35492 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:37:04 2026] [::1]:35492 Closing
-[Thu Feb 19 00:37:05 2026] [::1]:35504 Accepted
-[Thu Feb 19 00:37:05 2026] [::1]:35504 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:37:05 2026] [::1]:35504 Closing
-[Thu Feb 19 00:37:05 2026] [::1]:35512 Accepted
-[Thu Feb 19 00:37:05 2026] [::1]:35512 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:37:05 2026] [::1]:35512 Closing
-[Thu Feb 19 00:37:06 2026] [::1]:35516 Accepted
-[Thu Feb 19 00:37:06 2026] [::1]:35516 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:37:06 2026] [::1]:35516 Closing
-[Thu Feb 19 00:37:06 2026] [::1]:35530 Accepted
-[Thu Feb 19 00:37:06 2026] [::1]:35530 [200]: GET /api.php?resource=data
-[Thu Feb 19 00:37:06 2026] [::1]:35530 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46030 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46030 [200]: GET /index.html
-[Thu Feb 19 00:37:07 2026] [::1]:46030 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46032 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46042 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46048 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46032 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:37:07 2026] [::1]:46042 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:37:07 2026] [::1]:46032 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46042 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46048 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:37:07 2026] [::1]:46048 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46052 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46052 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:37:07 2026] [::1]:46052 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46054 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46056 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46070 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46086 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46054 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:37:07 2026] [::1]:46056 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:37:07 2026] [::1]:46070 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:37:07 2026] [::1]:46054 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46056 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46070 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46086 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:37:07 2026] [::1]:46086 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46090 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46090 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:37:07 2026] [::1]:46090 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46092 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46092 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:37:07 2026] [::1]:46092 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46102 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46102 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:37:07 2026] [::1]:46102 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46112 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46112 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:37:07 2026] [::1]:46112 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46118 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46124 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46126 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46142 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46146 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46118 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:37:07 2026] [::1]:46118 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46124 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:37:07 2026] [::1]:46124 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46126 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:37:07 2026] [::1]:46126 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46142 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:37:07 2026] [::1]:46142 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46146 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:37:07 2026] [::1]:46146 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46158 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46158 [200]: GET /index.html
-[Thu Feb 19 00:37:07 2026] [::1]:46158 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46174 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46184 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46196 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46174 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:37:07 2026] [::1]:46174 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46184 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:37:07 2026] [::1]:46184 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46196 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:37:07 2026] [::1]:46196 Closing
-[Thu Feb 19 00:37:07 2026] [::1]:46204 Accepted
-[Thu Feb 19 00:37:07 2026] [::1]:46204 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:37:07 2026] [::1]:46204 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46214 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46222 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46232 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46234 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46214 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46222 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46214 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46222 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46232 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46232 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46234 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46234 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46242 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46242 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:37:08 2026] [::1]:46242 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46256 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46266 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46272 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46274 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46276 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46288 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46256 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:37:08 2026] [::1]:46256 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46266 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:37:08 2026] [::1]:46266 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46272 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:37:08 2026] [::1]:46274 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:37:08 2026] [::1]:46276 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:37:08 2026] [::1]:46272 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46274 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46276 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46288 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:37:08 2026] [::1]:46288 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46290 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46292 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46290 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:37:08 2026] [::1]:46290 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46292 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:37:08 2026] [::1]:46292 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46304 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46304 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:37:08 2026] [::1]:46304 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46320 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46320 [200]: GET /api.php?resource=booked-slots&date=2026-02-21&doctor=rosero
-[Thu Feb 19 00:37:08 2026] [::1]:46320 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46334 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46346 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46334 [200]: GET /images/optimized/service-consulta.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46346 [200]: GET /images/optimized/service-telemedicina.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46334 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46346 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46350 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46362 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46370 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46382 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46350 [200]: GET /images/optimized/service-laser.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46362 [200]: GET /images/optimized/service-rejuvenecimiento.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46370 [200]: GET /images/optimized/service-acne.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46350 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46362 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46370 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46382 [200]: GET /images/optimized/service-cancer.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46382 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46396 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46396 [200]: GET /images/optimized/team-rosero.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46396 Closing
-[Thu Feb 19 00:37:08 2026] [::1]:46402 Accepted
-[Thu Feb 19 00:37:08 2026] [::1]:46402 [200]: GET /images/optimized/team-narvaez.avif
-[Thu Feb 19 00:37:08 2026] [::1]:46402 Closing
-[Thu Feb 19 00:37:09 2026] [::1]:46414 Accepted
-[Thu Feb 19 00:37:09 2026] [::1]:46414 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:37:09 2026] [::1]:46414 Closing
-[Thu Feb 19 00:37:10 2026] [::1]:46424 Accepted
-[Thu Feb 19 00:37:10 2026] [::1]:46424 [200]: GET /api.php?resource=availability
-[Thu Feb 19 00:37:10 2026] [::1]:46424 Closing
-[Thu Feb 19 00:37:10 2026] [::1]:46428 Accepted
-[Thu Feb 19 00:37:10 2026] [::1]:46428 [200]: GET /index.html
-[Thu Feb 19 00:37:10 2026] [::1]:46428 Closing
-[Thu Feb 19 00:37:10 2026] [::1]:46440 Accepted
-[Thu Feb 19 00:37:10 2026] [::1]:46448 Accepted
-[Thu Feb 19 00:37:10 2026] [::1]:46464 Accepted
-[Thu Feb 19 00:37:10 2026] [::1]:46440 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:37:10 2026] [::1]:46440 Closing
-[Thu Feb 19 00:37:10 2026] [::1]:46448 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:37:10 2026] [::1]:46448 Closing
-[Thu Feb 19 00:37:10 2026] [::1]:46464 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:37:10 2026] [::1]:46464 Closing
-[Thu Feb 19 00:37:10 2026] [::1]:46468 Accepted
-[Thu Feb 19 00:37:10 2026] [::1]:46468 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:37:10 2026] [::1]:46468 Closing
-[Thu Feb 19 00:37:10 2026] [::1]:46478 Accepted
-[Thu Feb 19 00:37:10 2026] [::1]:46488 Accepted
-[Thu Feb 19 00:37:10 2026] [::1]:46490 Accepted
-[Thu Feb 19 00:37:10 2026] [::1]:46496 Accepted
-[Thu Feb 19 00:37:10 2026] [::1]:46478 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:37:10 2026] [::1]:46488 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:37:10 2026] [::1]:46490 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:37:10 2026] [::1]:46496 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:37:10 2026] [::1]:46478 Closing
-[Thu Feb 19 00:37:10 2026] [::1]:46488 Closing
-[Thu Feb 19 00:37:10 2026] [::1]:46490 Closing
-[Thu Feb 19 00:37:10 2026] [::1]:46496 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46498 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46498 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:37:11 2026] [::1]:46498 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46500 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46504 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46500 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:37:11 2026] [::1]:46512 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46504 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:37:11 2026] [::1]:46526 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46512 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:37:11 2026] [::1]:46538 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46500 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46526 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:37:11 2026] [::1]:46504 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46538 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:37:11 2026] [::1]:46512 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46526 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46538 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46552 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46558 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46552 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:37:11 2026] [::1]:46552 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46572 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46558 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:37:11 2026] [::1]:46572 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:37:11 2026] [::1]:46558 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46572 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46576 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46576 [200]: GET /index.html
-[Thu Feb 19 00:37:11 2026] [::1]:46576 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46586 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46600 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46608 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46586 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
-[Thu Feb 19 00:37:11 2026] [::1]:46600 [200]: GET /styles-deferred.css?v=ui-20260219-deferred4-mobiletypelock1-a11yfocus1-chatsanitize1
-[Thu Feb 19 00:37:11 2026] [::1]:46608 [200]: GET /hero-woman.jpg
-[Thu Feb 19 00:37:11 2026] [::1]:46586 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46600 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46608 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46618 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46618 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1
-[Thu Feb 19 00:37:11 2026] [::1]:46618 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46626 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46642 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46656 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46658 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46626 [200]: GET /images/optimized/showcase-hero.avif
-[Thu Feb 19 00:37:11 2026] [::1]:46626 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46642 [200]: GET /images/optimized/showcase-diagnostic.avif
-[Thu Feb 19 00:37:11 2026] [::1]:46642 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46656 [200]: GET /images/optimized/showcase-clinic.avif
-[Thu Feb 19 00:37:11 2026] [::1]:46656 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46658 [200]: GET /images/optimized/showcase-treatment.avif
-[Thu Feb 19 00:37:11 2026] [::1]:46658 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46668 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46668 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2
-[Thu Feb 19 00:37:11 2026] [::1]:46668 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46670 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46672 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46686 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46702 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46672 [200]: GET /api.php?resource=reviews
-[Thu Feb 19 00:37:11 2026] [::1]:46672 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46716 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46728 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46742 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46670 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4
-[Thu Feb 19 00:37:11 2026] [::1]:46716 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
-[Thu Feb 19 00:37:11 2026] [::1]:46686 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
-[Thu Feb 19 00:37:11 2026] [::1]:46702 [200]: GET /chat-engine.js?v=figo-chat-20260218-phase2-linkrel1-textclean1
-[Thu Feb 19 00:37:11 2026] [::1]:46728 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
-[Thu Feb 19 00:37:11 2026] [::1]:46670 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46716 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46686 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46702 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46728 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46756 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46742 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1
-[Thu Feb 19 00:37:11 2026] [::1]:46768 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46756 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
-[Thu Feb 19 00:37:11 2026] [::1]:46768 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
-[Thu Feb 19 00:37:11 2026] [::1]:46742 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46756 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46768 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46778 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46778 [200]: GET /figo-chat.php
-[Thu Feb 19 00:37:11 2026] [::1]:46778 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46782 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46782 [404]: GET /data/ - No such file or directory
-[Thu Feb 19 00:37:11 2026] [::1]:46782 Closing
-[Thu Feb 19 00:37:11 2026] [::1]:46784 Accepted
-[Thu Feb 19 00:37:11 2026] [::1]:46784 [404]: GET /uploads/ - No such file or directory
-[Thu Feb 19 00:37:11 2026] [::1]:46784 Closing
+[Thu Feb 19 03:40:30 2026] PHP 8.3.6 Development Server (http://localhost:8000) started
+[Thu Feb 19 03:41:43 2026] [::1]:53082 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53082 [200]: GET /
+[Thu Feb 19 03:41:43 2026] [::1]:53082 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53096 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53096 [200]: GET /admin.html
+[Thu Feb 19 03:41:43 2026] [::1]:53096 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53108 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53122 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53108 [200]: GET /styles.css
+[Thu Feb 19 03:41:43 2026] [::1]:53128 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53122 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:43 2026] [::1]:53128 [200]: GET /admin.css
+[Thu Feb 19 03:41:43 2026] [::1]:53108 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53122 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53128 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53138 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53150 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53156 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53138 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:43 2026] [::1]:53138 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53156 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:43 2026] [::1]:53156 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53150 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1-stateclass1
+[Thu Feb 19 03:41:43 2026] [::1]:53150 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53164 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53164 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:43 2026] [::1]:53164 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53178 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53178 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:43 2026] [::1]:53178 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53186 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53186 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:43 2026] [::1]:53186 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53200 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53200 [200]: GET /admin-auth.php?action=status
+[Thu Feb 19 03:41:43 2026] [::1]:53200 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53216 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53220 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53230 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53234 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53238 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53216 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:43 2026] [::1]:53216 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53246 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53220 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:43 2026] [::1]:53230 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:43 2026] [::1]:53234 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:43 2026] [::1]:53238 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:43 2026] [::1]:53220 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53230 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53234 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53238 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53260 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53246 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:43 2026] [::1]:53246 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53268 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53276 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53292 Accepted
+[Thu Feb 19 03:41:43 2026] [::1]:53260 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:43 2026] [::1]:53260 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53268 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:43 2026] [::1]:53268 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53276 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:43 2026] [::1]:53276 Closing
+[Thu Feb 19 03:41:43 2026] [::1]:53292 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:43 2026] [::1]:53292 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53300 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53300 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53300 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53314 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53314 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53314 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53324 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53324 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:41:44 2026] [::1]:53324 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53328 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53328 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:41:44 2026] [::1]:53328 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53332 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53332 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53332 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53334 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53334 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:41:44 2026] [::1]:53334 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53350 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53366 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53372 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53350 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53366 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:41:44 2026] [::1]:53374 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53372 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:41:44 2026] [::1]:53378 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53374 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:41:44 2026] [::1]:53380 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53350 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53366 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53378 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:41:44 2026] [::1]:53372 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53380 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53374 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53378 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53380 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53396 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53396 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53396 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53400 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53400 [200]: GET /admin.html
+[Thu Feb 19 03:41:44 2026] [::1]:53400 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53416 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53416 [200]: GET /styles.css
+[Thu Feb 19 03:41:44 2026] [::1]:53416 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53432 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53432 [200]: GET /admin.css
+[Thu Feb 19 03:41:44 2026] [::1]:53432 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53434 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53434 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1-stateclass1
+[Thu Feb 19 03:41:44 2026] [::1]:53434 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53444 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53444 [200]: GET /admin-auth.php?action=status
+[Thu Feb 19 03:41:44 2026] [::1]:53444 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53446 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53446 [200]: GET /
+[Thu Feb 19 03:41:44 2026] [::1]:53446 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53448 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53456 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53448 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:44 2026] [::1]:53460 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53456 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:44 2026] [::1]:53460 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:44 2026] [::1]:53448 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53456 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53460 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53476 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53476 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:44 2026] [::1]:53476 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53490 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53490 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:44 2026] [::1]:53490 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53496 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53496 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53496 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53504 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53504 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:44 2026] [::1]:53504 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53516 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53532 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53538 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53542 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53556 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53572 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53516 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:44 2026] [::1]:53516 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53532 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:44 2026] [::1]:53532 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53538 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:44 2026] [::1]:53538 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53542 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53542 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53556 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53556 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53572 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53572 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53578 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53584 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53598 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53578 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53584 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53578 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53584 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53598 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:44 2026] [::1]:53598 Closing
+[Thu Feb 19 03:41:44 2026] [::1]:53612 Accepted
+[Thu Feb 19 03:41:44 2026] [::1]:53612 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:44 2026] [::1]:53612 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53618 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53618 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53618 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53630 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53630 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:41:45 2026] [::1]:53630 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53638 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53642 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53638 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:41:45 2026] [::1]:53642 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53638 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53642 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53644 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53660 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53644 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:41:45 2026] [::1]:53674 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53660 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53682 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53674 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:41:45 2026] [::1]:53692 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53644 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53682 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:41:45 2026] [::1]:53702 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53660 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53692 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:41:45 2026] [::1]:53702 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:41:45 2026] [::1]:53674 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53682 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53692 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53702 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53712 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53712 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53712 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53716 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53716 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53716 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53730 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53730 [200]: GET /admin.html
+[Thu Feb 19 03:41:45 2026] [::1]:53730 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53736 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53750 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53736 [200]: GET /styles.css
+[Thu Feb 19 03:41:45 2026] [::1]:53750 [200]: GET /admin.css
+[Thu Feb 19 03:41:45 2026] [::1]:53736 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53750 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53766 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53766 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1-stateclass1
+[Thu Feb 19 03:41:45 2026] [::1]:53766 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53774 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53774 [200]: GET /admin-auth.php?action=status
+[Thu Feb 19 03:41:45 2026] [::1]:53774 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53784 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53784 [200]: GET /
+[Thu Feb 19 03:41:45 2026] [::1]:53784 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53788 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53804 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53788 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:45 2026] [::1]:53788 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53804 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:45 2026] [::1]:53804 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53818 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53818 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:45 2026] [::1]:53818 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53820 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53820 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:45 2026] [::1]:53820 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53832 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53832 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:45 2026] [::1]:53832 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53848 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53848 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53848 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53850 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53862 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53868 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53880 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53886 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53902 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53850 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:45 2026] [::1]:53862 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:45 2026] [::1]:53868 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:45 2026] [::1]:53880 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:45 2026] [::1]:53886 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53902 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53850 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53862 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53868 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53880 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53886 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53902 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53908 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53922 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53926 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53942 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53908 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53922 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53926 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53908 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53922 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53926 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53942 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:45 2026] [::1]:53942 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53946 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53946 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53946 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53952 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53962 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53952 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53962 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:41:45 2026] [::1]:53952 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53962 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53970 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53982 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53998 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:54008 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:54024 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:54028 Accepted
+[Thu Feb 19 03:41:45 2026] [::1]:53970 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:41:45 2026] [::1]:53982 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:53998 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:41:45 2026] [::1]:54008 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:41:45 2026] [::1]:54024 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:41:45 2026] [::1]:54028 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:41:45 2026] [::1]:53970 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53982 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:53998 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:54008 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:54024 Closing
+[Thu Feb 19 03:41:45 2026] [::1]:54028 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54040 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54048 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54052 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54040 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:41:46 2026] [::1]:54040 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54048 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:41:46 2026] [::1]:54048 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54056 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54052 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:41:46 2026] [::1]:54052 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54056 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:41:46 2026] [::1]:54056 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54068 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54068 [200]: GET /api.php?resource=availability
+[Thu Feb 19 03:41:46 2026] [::1]:54068 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54080 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54080 [200]: GET /api.php?resource=booked-slots&date=2026-02-20&doctor=rosero
+[Thu Feb 19 03:41:46 2026] [::1]:54080 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54096 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54096 [200]: GET /images/optimized/service-consulta.avif
+[Thu Feb 19 03:41:46 2026] [::1]:54096 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54100 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54104 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54100 [200]: GET /images/optimized/service-telemedicina.avif
+[Thu Feb 19 03:41:46 2026] [::1]:54104 [200]: GET /images/optimized/service-laser.avif
+[Thu Feb 19 03:41:46 2026] [::1]:54100 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54104 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54108 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54112 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54108 [200]: GET /images/optimized/service-rejuvenecimiento.avif
+[Thu Feb 19 03:41:46 2026] [::1]:54116 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54112 [200]: GET /images/optimized/service-acne.avif
+[Thu Feb 19 03:41:46 2026] [::1]:54116 [200]: GET /images/optimized/service-cancer.avif
+[Thu Feb 19 03:41:46 2026] [::1]:54108 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54112 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54116 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54132 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54132 [200]: GET /images/optimized/team-rosero.avif
+[Thu Feb 19 03:41:46 2026] [::1]:54132 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54138 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54138 [200]: GET /images/optimized/team-narvaez.avif
+[Thu Feb 19 03:41:46 2026] [::1]:54138 Closing
+[Thu Feb 19 03:41:46 2026] [::1]:54148 Accepted
+[Thu Feb 19 03:41:46 2026] [::1]:54148 [200]: GET /api.php?resource=reviews
+[Thu Feb 19 03:41:46 2026] [::1]:54148 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54160 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54160 [200]: GET /admin.html
+[Thu Feb 19 03:41:47 2026] [::1]:54160 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54162 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54176 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54162 [200]: GET /styles.css
+[Thu Feb 19 03:41:47 2026] [::1]:54176 [200]: GET /admin.css
+[Thu Feb 19 03:41:47 2026] [::1]:54162 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54176 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54184 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54184 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1-stateclass1
+[Thu Feb 19 03:41:47 2026] [::1]:54184 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54194 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54194 [200]: GET /admin-auth.php?action=status
+[Thu Feb 19 03:41:47 2026] [::1]:54194 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54210 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54210 [401]: POST /admin-auth.php?action=login
+[Thu Feb 19 03:41:47 2026] [::1]:54210 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54220 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54220 [200]: GET /
+[Thu Feb 19 03:41:47 2026] [::1]:54220 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54226 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54232 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54240 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54226 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:47 2026] [::1]:54232 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:47 2026] [::1]:54240 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:47 2026] [::1]:54226 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54232 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54240 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54256 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54256 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:47 2026] [::1]:54256 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54272 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54282 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54272 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:47 2026] [::1]:54282 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54272 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54282 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54284 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54294 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54310 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54324 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54338 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54346 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54284 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:47 2026] [::1]:54294 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:47 2026] [::1]:54284 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54294 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54310 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:47 2026] [::1]:54310 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54324 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:47 2026] [::1]:54324 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54338 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54338 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54346 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54346 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54358 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54362 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54378 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54380 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54358 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54362 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54378 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54358 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54362 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54378 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54380 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:47 2026] [::1]:54380 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54392 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54392 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54392 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54402 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54406 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54418 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54428 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54432 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54448 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54402 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54406 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:41:47 2026] [::1]:54418 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:41:47 2026] [::1]:54402 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54406 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54418 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54428 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54428 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54432 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:41:47 2026] [::1]:54432 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54448 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54448 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54458 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54468 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54470 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54472 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54474 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54458 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:41:47 2026] [::1]:54468 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:41:47 2026] [::1]:54470 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:41:47 2026] [::1]:54472 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:41:47 2026] [::1]:54474 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54458 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54468 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54470 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54472 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54474 Closing
+[Thu Feb 19 03:41:47 2026] [::1]:54482 Accepted
+[Thu Feb 19 03:41:47 2026] [::1]:54482 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:41:47 2026] [::1]:54482 Closing
+[Thu Feb 19 03:41:48 2026] [::1]:54496 Accepted
+[Thu Feb 19 03:41:48 2026] [::1]:54496 [200]: GET /api.php?resource=availability
+[Thu Feb 19 03:41:48 2026] [::1]:54496 Closing
+[Thu Feb 19 03:41:48 2026] [::1]:54512 Accepted
+[Thu Feb 19 03:41:48 2026] [::1]:54512 [200]: GET /
+[Thu Feb 19 03:41:48 2026] [::1]:54512 Closing
+[Thu Feb 19 03:41:48 2026] [::1]:54520 Accepted
+[Thu Feb 19 03:41:48 2026] [::1]:54524 Accepted
+[Thu Feb 19 03:41:48 2026] [::1]:54520 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:48 2026] [::1]:54534 Accepted
+[Thu Feb 19 03:41:48 2026] [::1]:54524 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:48 2026] [::1]:54534 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:48 2026] [::1]:54520 Closing
+[Thu Feb 19 03:41:48 2026] [::1]:54524 Closing
+[Thu Feb 19 03:41:48 2026] [::1]:54534 Closing
+[Thu Feb 19 03:41:48 2026] [::1]:54548 Accepted
+[Thu Feb 19 03:41:48 2026] [::1]:54548 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:48 2026] [::1]:54548 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54554 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54558 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54554 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:49 2026] [::1]:54558 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54554 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54558 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54568 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54570 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54578 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54580 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54594 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54598 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54568 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54568 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54606 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54570 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54578 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54580 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54594 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54598 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54606 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54570 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54578 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54580 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54594 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54598 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54606 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54618 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54622 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54624 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54618 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54622 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54624 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:49 2026] [::1]:54618 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54622 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54624 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54636 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54636 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54636 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54646 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54646 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54646 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54660 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54660 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:41:49 2026] [::1]:54660 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54664 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54664 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:41:49 2026] [::1]:54664 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54668 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54668 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54668 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54672 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54672 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54672 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54686 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54686 [200]: GET /api.php?resource=availability
+[Thu Feb 19 03:41:49 2026] [::1]:54686 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54696 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54696 [200]: GET /api.php?resource=booked-slots&date=2026-02-26&doctor=rosero
+[Thu Feb 19 03:41:49 2026] [::1]:54696 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54710 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54710 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54710 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54726 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54726 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:41:49 2026] [::1]:54726 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54728 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54744 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54758 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54768 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54784 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54728 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:41:49 2026] [::1]:54728 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54744 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:41:49 2026] [::1]:54744 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54758 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:41:49 2026] [::1]:54768 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:41:49 2026] [::1]:54784 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:41:49 2026] [::1]:54758 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54768 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54784 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54800 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54806 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54812 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54826 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54842 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54846 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54800 [200]: GET /images/optimized/service-consulta.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54806 [200]: GET /images/optimized/service-telemedicina.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54812 [200]: GET /images/optimized/service-laser.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54800 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54806 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54812 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54826 [200]: GET /images/optimized/service-rejuvenecimiento.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54826 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54842 [200]: GET /images/optimized/service-acne.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54842 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54846 [200]: GET /images/optimized/service-cancer.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54846 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54858 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54862 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54858 [200]: GET /images/optimized/team-rosero.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54862 [200]: GET /images/optimized/team-narvaez.avif
+[Thu Feb 19 03:41:49 2026] [::1]:54858 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54862 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:54870 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:54870 [200]: GET /api.php?resource=health
+[Thu Feb 19 03:41:49 2026] [::1]:54870 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:37384 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:37384 [401]: GET /api.php?resource=data
+[Thu Feb 19 03:41:49 2026] [::1]:37384 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:37386 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:37386 [200]: GET /api.php?resource=availability
+[Thu Feb 19 03:41:49 2026] [::1]:37386 Closing
+[Thu Feb 19 03:41:49 2026] [::1]:37398 Accepted
+[Thu Feb 19 03:41:49 2026] [::1]:37398 [200]: GET /api.php?resource=reviews
+[Thu Feb 19 03:41:49 2026] [::1]:37398 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37400 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37400 [200]: GET /api.php?resource=health
+[Thu Feb 19 03:41:50 2026] [::1]:37400 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37410 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37410 [200]: GET /api.php?resource=reviews
+[Thu Feb 19 03:41:50 2026] [::1]:37410 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37418 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37418 [200]: GET /admin.html
+[Thu Feb 19 03:41:50 2026] [::1]:37418 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37432 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37432 [200]: GET /styles.css
+[Thu Feb 19 03:41:50 2026] [::1]:37432 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37446 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37446 [200]: GET /admin.css
+[Thu Feb 19 03:41:50 2026] [::1]:37446 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37456 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37456 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1-stateclass1
+[Thu Feb 19 03:41:50 2026] [::1]:37456 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37464 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37464 [200]: GET /admin-auth.php?action=status
+[Thu Feb 19 03:41:50 2026] [::1]:37464 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37480 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37480 [401]: POST /admin-auth.php?action=login
+[Thu Feb 19 03:41:50 2026] [::1]:37480 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37482 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37482 [200]: GET /admin.html
+[Thu Feb 19 03:41:50 2026] [::1]:37482 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37484 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37496 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37504 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37484 [200]: GET /styles.css
+[Thu Feb 19 03:41:50 2026] [::1]:37496 [200]: GET /admin.css
+[Thu Feb 19 03:41:50 2026] [::1]:37504 [200]: GET /admin.js?v=figo-admin-20260218-linkrel1-stateclass1
+[Thu Feb 19 03:41:50 2026] [::1]:37484 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37496 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37504 Closing
+[Thu Feb 19 03:41:50 2026] [::1]:37518 Accepted
+[Thu Feb 19 03:41:50 2026] [::1]:37518 [200]: GET /admin-auth.php?action=status
+[Thu Feb 19 03:41:50 2026] [::1]:37518 Closing
+[Thu Feb 19 03:41:51 2026] [::1]:37520 Accepted
+[Thu Feb 19 03:41:51 2026] [::1]:37520 [401]: POST /admin-auth.php?action=login
+[Thu Feb 19 03:41:51 2026] [::1]:37520 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37530 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37530 [200]: GET /
+[Thu Feb 19 03:41:52 2026] [::1]:37530 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37540 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37548 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37540 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:52 2026] [::1]:37540 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37550 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37548 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:52 2026] [::1]:37548 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37550 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:52 2026] [::1]:37550 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37566 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37566 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:52 2026] [::1]:37566 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37580 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37584 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37580 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:52 2026] [::1]:37584 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37580 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37584 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37586 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37596 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37606 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37612 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37616 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37628 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37586 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:52 2026] [::1]:37596 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:52 2026] [::1]:37606 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:52 2026] [::1]:37612 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:52 2026] [::1]:37616 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37628 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37586 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37596 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37606 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37612 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37616 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37628 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37630 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37638 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37646 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37650 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37630 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37638 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37646 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37650 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:52 2026] [::1]:37630 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37638 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37646 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37650 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37664 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37664 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37664 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37680 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37680 [200]: GET /
+[Thu Feb 19 03:41:52 2026] [::1]:37680 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37690 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37700 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37690 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:52 2026] [::1]:37700 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:52 2026] [::1]:37690 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37700 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37714 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37714 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:52 2026] [::1]:37714 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37728 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37728 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:52 2026] [::1]:37728 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37740 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37740 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:52 2026] [::1]:37740 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37756 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37764 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37772 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37782 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37788 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37756 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:52 2026] [::1]:37764 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:52 2026] [::1]:37756 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37764 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37772 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:52 2026] [::1]:37772 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37782 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:52 2026] [::1]:37782 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37788 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37788 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37792 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37800 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37792 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37804 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37800 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37816 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37804 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37824 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37792 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37816 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37800 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37824 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37804 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37816 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37824 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37834 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37834 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:52 2026] [::1]:37834 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37840 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37840 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37840 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37844 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37844 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37844 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37856 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37856 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:41:52 2026] [::1]:37856 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37860 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37868 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37882 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37888 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37900 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37906 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37860 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:41:52 2026] [::1]:37868 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37860 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37882 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:41:52 2026] [::1]:37868 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37882 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37888 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37888 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37900 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:41:52 2026] [::1]:37906 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:41:52 2026] [::1]:37900 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37906 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37914 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37914 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:41:52 2026] [::1]:37914 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37928 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37928 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37928 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37932 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37932 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:41:52 2026] [::1]:37932 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37948 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37948 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:41:52 2026] [::1]:37948 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37964 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37964 [200]: GET /
+[Thu Feb 19 03:41:52 2026] [::1]:37964 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37978 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37980 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37978 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:52 2026] [::1]:37992 Accepted
+[Thu Feb 19 03:41:52 2026] [::1]:37980 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:52 2026] [::1]:37992 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:52 2026] [::1]:37978 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37980 Closing
+[Thu Feb 19 03:41:52 2026] [::1]:37992 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38002 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38002 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:53 2026] [::1]:38002 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38014 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38014 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:53 2026] [::1]:38014 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38020 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38020 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38020 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38030 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38034 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38046 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38048 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38050 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38052 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38030 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38034 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38046 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38030 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38034 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38046 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38048 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38048 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38050 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38050 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38052 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38052 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38054 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38058 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38062 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38072 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38054 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38058 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38054 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38058 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38062 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38062 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38072 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:53 2026] [::1]:38072 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38088 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38088 [200]: GET /
+[Thu Feb 19 03:41:53 2026] [::1]:38088 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38104 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38108 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38104 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:53 2026] [::1]:38108 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:53 2026] [::1]:38104 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38108 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38112 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38112 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:53 2026] [::1]:38112 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38126 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38126 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:53 2026] [::1]:38126 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38132 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38136 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38132 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:53 2026] [::1]:38136 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38132 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38136 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38148 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38154 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38166 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38172 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38174 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38186 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38148 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38148 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38154 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38154 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38166 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38166 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38172 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38172 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38174 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38174 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38186 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:53 2026] [::1]:38186 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38194 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38200 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38194 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38202 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38200 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38214 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38202 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38194 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38214 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38200 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38202 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38214 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38218 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38218 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38218 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38220 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38220 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38220 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38234 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38236 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38250 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38234 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:41:53 2026] [::1]:38236 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:41:53 2026] [::1]:38250 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38234 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38236 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38250 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38256 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38266 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38278 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38256 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:41:53 2026] [::1]:38266 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38256 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38266 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38278 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:41:53 2026] [::1]:38278 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38282 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38288 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38282 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:41:53 2026] [::1]:38288 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:41:53 2026] [::1]:38282 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38288 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38290 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38306 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38318 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38290 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:41:53 2026] [::1]:38290 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38306 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38306 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38318 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38318 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38330 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38330 [200]: GET /
+[Thu Feb 19 03:41:53 2026] [::1]:38330 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38338 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38354 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38364 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38338 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:53 2026] [::1]:38354 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:53 2026] [::1]:38338 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38354 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38364 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:53 2026] [::1]:38364 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38366 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38366 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:53 2026] [::1]:38366 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38372 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38376 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38372 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:53 2026] [::1]:38376 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38372 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38376 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38380 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38394 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38400 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38410 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38380 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38394 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38400 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38410 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:53 2026] [::1]:38380 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38394 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38400 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38410 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38422 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38434 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38450 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38462 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38466 Accepted
+[Thu Feb 19 03:41:53 2026] [::1]:38422 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38434 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38450 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38422 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38434 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38450 Closing
+[Thu Feb 19 03:41:53 2026] [::1]:38462 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:53 2026] [::1]:38462 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38476 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38466 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38466 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38476 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:54 2026] [::1]:38476 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38488 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38488 [200]: GET /
+[Thu Feb 19 03:41:54 2026] [::1]:38488 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38500 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38514 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38500 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:54 2026] [::1]:38524 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38514 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:54 2026] [::1]:38524 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:54 2026] [::1]:38500 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38514 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38524 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38532 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38532 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:54 2026] [::1]:38532 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38548 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38558 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38548 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:54 2026] [::1]:38548 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38558 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38558 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38570 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38572 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38574 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38576 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38570 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:54 2026] [::1]:38572 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:54 2026] [::1]:38574 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:54 2026] [::1]:38576 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:54 2026] [::1]:38570 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38572 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38574 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38576 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38584 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38592 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38596 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38612 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38620 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38628 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38584 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38592 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38596 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38584 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38592 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38596 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38612 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38620 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38628 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:54 2026] [::1]:38612 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38620 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38628 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38642 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38642 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38642 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38654 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38664 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38672 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38654 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38664 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:41:54 2026] [::1]:38654 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38672 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:41:54 2026] [::1]:38664 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38672 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38676 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38684 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38676 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38676 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38686 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38700 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38710 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38720 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38684 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:41:54 2026] [::1]:38684 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38686 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38700 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:41:54 2026] [::1]:38710 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:41:54 2026] [::1]:38720 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:41:54 2026] [::1]:38686 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38700 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38710 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38720 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38724 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38732 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38734 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38724 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:41:54 2026] [::1]:38724 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38732 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38732 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38734 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38734 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38736 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38736 [200]: GET /
+[Thu Feb 19 03:41:54 2026] [::1]:38736 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38740 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38742 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38740 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:54 2026] [::1]:38754 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38742 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:54 2026] [::1]:38754 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:54 2026] [::1]:38740 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38742 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38754 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38768 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38768 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:54 2026] [::1]:38768 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38784 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38788 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38784 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:54 2026] [::1]:38788 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38784 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38788 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38804 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38816 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38830 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38836 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38844 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38846 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38804 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:54 2026] [::1]:38816 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:54 2026] [::1]:38830 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:54 2026] [::1]:38836 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:54 2026] [::1]:38844 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:54 2026] [::1]:38846 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38804 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38816 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38830 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38836 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38844 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38846 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38854 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38870 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38884 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38892 Accepted
+[Thu Feb 19 03:41:54 2026] [::1]:38854 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38854 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38870 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38884 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38892 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:54 2026] [::1]:38870 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38884 Closing
+[Thu Feb 19 03:41:54 2026] [::1]:38892 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38894 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38894 [200]: GET /
+[Thu Feb 19 03:41:55 2026] [::1]:38894 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38900 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38900 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:55 2026] [::1]:38900 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38906 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38906 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:55 2026] [::1]:38906 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38914 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38914 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:55 2026] [::1]:38914 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38916 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38916 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:55 2026] [::1]:38916 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38920 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38926 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38920 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:55 2026] [::1]:38932 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38926 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:55 2026] [::1]:38946 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38932 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:55 2026] [::1]:38960 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38920 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38946 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:55 2026] [::1]:38974 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38926 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38960 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:55 2026] [::1]:38974 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:38932 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38946 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38960 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38974 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38982 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38992 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39000 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39008 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39018 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39022 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:38982 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:38992 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:38982 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:38992 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39000 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39000 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39008 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39008 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39018 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39018 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39022 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:55 2026] [::1]:39022 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39032 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39032 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39032 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39048 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39048 [200]: GET /
+[Thu Feb 19 03:41:55 2026] [::1]:39048 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39050 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39062 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39050 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:55 2026] [::1]:39050 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39062 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:55 2026] [::1]:39062 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39078 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39078 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:55 2026] [::1]:39078 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39092 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39092 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:55 2026] [::1]:39092 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39096 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39098 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39096 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:55 2026] [::1]:39114 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39098 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:55 2026] [::1]:39114 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:55 2026] [::1]:39096 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39098 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39114 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39116 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39124 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39130 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39116 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:55 2026] [::1]:39124 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:55 2026] [::1]:39130 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39116 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39124 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39130 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39140 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39146 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39160 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39176 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39190 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39140 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39140 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39146 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39146 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39160 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39160 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39176 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39176 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39190 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39190 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39202 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39202 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:55 2026] [::1]:39202 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39218 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39218 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39218 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39224 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39226 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39228 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39230 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39242 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39248 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39224 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39224 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39226 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:41:55 2026] [::1]:39226 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39228 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:41:55 2026] [::1]:39228 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39230 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39230 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39256 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39242 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:41:55 2026] [::1]:39248 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39266 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39268 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39242 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39248 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39270 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39256 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:41:55 2026] [::1]:39256 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39266 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:41:55 2026] [::1]:39268 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:41:55 2026] [::1]:39266 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39268 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39270 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:41:55 2026] [::1]:39280 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39270 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39280 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39280 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39284 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39284 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39284 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39288 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39288 [200]: GET /
+[Thu Feb 19 03:41:55 2026] [::1]:39288 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39292 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39296 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39308 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39292 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:55 2026] [::1]:39296 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:55 2026] [::1]:39292 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39296 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39308 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:55 2026] [::1]:39308 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39318 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39318 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:55 2026] [::1]:39318 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39322 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39332 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39322 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:55 2026] [::1]:39332 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39322 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39332 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39344 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39360 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39374 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39390 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39404 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39344 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:55 2026] [::1]:39344 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39410 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39360 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:55 2026] [::1]:39360 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39410 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39374 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:55 2026] [::1]:39390 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:55 2026] [::1]:39404 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:55 2026] [::1]:39410 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39374 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39390 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39404 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39422 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39428 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39432 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39422 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39422 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39428 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39428 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39442 Accepted
+[Thu Feb 19 03:41:55 2026] [::1]:39432 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39432 Closing
+[Thu Feb 19 03:41:55 2026] [::1]:39442 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:55 2026] [::1]:39442 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39444 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39444 [200]: GET /
+[Thu Feb 19 03:41:56 2026] [::1]:39444 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39458 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39460 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39476 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39458 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:56 2026] [::1]:39458 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39460 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:56 2026] [::1]:39476 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:56 2026] [::1]:39460 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39476 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39482 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39482 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:56 2026] [::1]:39482 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39484 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39492 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39484 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:56 2026] [::1]:39492 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39484 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39492 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39502 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39518 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39522 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39528 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39544 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39546 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39502 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:56 2026] [::1]:39502 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39518 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:56 2026] [::1]:39518 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39522 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:56 2026] [::1]:39522 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39528 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:56 2026] [::1]:39528 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39544 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39544 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39546 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39546 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39550 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39554 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39562 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39576 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39550 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39550 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39554 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39562 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39554 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39562 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39576 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:56 2026] [::1]:39576 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39592 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39592 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39592 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39608 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39614 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39630 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39646 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39662 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39668 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39608 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39614 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:41:56 2026] [::1]:39630 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:41:56 2026] [::1]:39646 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39662 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:41:56 2026] [::1]:39668 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39608 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39614 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39630 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39646 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39662 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39668 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39670 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39682 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39670 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:41:56 2026] [::1]:39696 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39682 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:41:56 2026] [::1]:39700 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39696 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:41:56 2026] [::1]:39708 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39670 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39700 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:41:56 2026] [::1]:39682 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39708 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39696 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39700 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39708 Closing
+[Thu Feb 19 03:41:56 2026] [::1]:39722 Accepted
+[Thu Feb 19 03:41:56 2026] [::1]:39722 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:41:56 2026] [::1]:39722 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39730 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39730 [200]: GET /
+[Thu Feb 19 03:41:57 2026] [::1]:39730 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39742 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39758 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39760 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39742 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:57 2026] [::1]:39758 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:57 2026] [::1]:39760 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:57 2026] [::1]:39742 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39758 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39760 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39764 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39764 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:57 2026] [::1]:39764 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39766 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39768 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39766 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:57 2026] [::1]:39768 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:39766 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39768 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39770 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39770 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:57 2026] [::1]:39770 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39780 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39782 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39796 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39780 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:57 2026] [::1]:39780 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39806 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39814 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39782 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:57 2026] [::1]:39782 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39796 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:57 2026] [::1]:39796 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39824 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39806 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:39814 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:39830 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39824 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:39842 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39830 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:39846 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39806 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39814 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39842 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:39824 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39846 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:57 2026] [::1]:39830 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39842 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39846 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39852 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39862 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39852 [200]: GET /
+[Thu Feb 19 03:41:57 2026] [::1]:39852 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39862 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:39862 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39868 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39868 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:41:57 2026] [::1]:39868 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39874 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39882 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39874 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:41:57 2026] [::1]:39882 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:41:57 2026] [::1]:39874 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39882 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39894 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39894 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:41:57 2026] [::1]:39894 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39906 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39910 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39914 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39930 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39906 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:41:57 2026] [::1]:39906 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39910 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:41:57 2026] [::1]:39910 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39914 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:41:57 2026] [::1]:39914 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39930 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:41:57 2026] [::1]:39930 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39934 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39944 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39934 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:41:57 2026] [::1]:39934 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39944 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:39944 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39960 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39960 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:41:57 2026] [::1]:39960 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:39976 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39986 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39976 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:39994 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39986 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:40006 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39994 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:40020 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:39976 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40006 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:39986 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40020 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:39994 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40006 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40020 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40036 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:40036 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:40036 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40044 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:40060 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:40066 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:40082 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:40084 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:40092 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:40044 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:40044 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40060 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:41:57 2026] [::1]:40060 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40066 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:41:57 2026] [::1]:40066 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40082 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:40082 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40084 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:41:57 2026] [::1]:40084 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40108 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:40092 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:41:57 2026] [::1]:40116 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:40108 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:41:57 2026] [::1]:40130 Accepted
+[Thu Feb 19 03:41:57 2026] [::1]:40092 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40108 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40116 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:41:57 2026] [::1]:40130 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:41:57 2026] [::1]:40116 Closing
+[Thu Feb 19 03:41:57 2026] [::1]:40130 Closing
+[Thu Feb 19 03:41:58 2026] [::1]:40144 Accepted
+[Thu Feb 19 03:41:58 2026] [::1]:40154 Accepted
+[Thu Feb 19 03:41:58 2026] [::1]:40164 Accepted
+[Thu Feb 19 03:41:58 2026] [::1]:40144 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:41:58 2026] [::1]:40144 Closing
+[Thu Feb 19 03:41:58 2026] [::1]:40154 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:41:58 2026] [::1]:40154 Closing
+[Thu Feb 19 03:41:58 2026] [::1]:40164 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:41:58 2026] [::1]:40164 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:54920 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54920 [200]: GET /
+[Thu Feb 19 03:42:00 2026] [::1]:54920 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:54922 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54928 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54930 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54922 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:00 2026] [::1]:54922 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:54928 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:00 2026] [::1]:54928 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:54930 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:00 2026] [::1]:54930 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:54938 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54938 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:00 2026] [::1]:54938 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:54942 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54952 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54942 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:00 2026] [::1]:54952 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:54942 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:54952 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:54968 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54970 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54984 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54996 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54968 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:00 2026] [::1]:54968 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:54970 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:00 2026] [::1]:54970 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55002 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55016 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:54984 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:00 2026] [::1]:54996 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:00 2026] [::1]:54984 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:54996 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55002 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55016 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55002 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55016 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55020 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55024 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55036 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55046 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55020 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55024 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55020 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55024 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55036 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55046 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:00 2026] [::1]:55036 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55046 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55050 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55050 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55050 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55060 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55070 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55060 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55084 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55086 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55060 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55100 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55070 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:00 2026] [::1]:55070 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55110 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55116 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55100 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:00 2026] [::1]:55084 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:00 2026] [::1]:55086 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55130 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55100 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55084 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55086 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55110 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55110 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55116 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:00 2026] [::1]:55116 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55130 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:00 2026] [::1]:55130 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55138 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55154 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55164 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55138 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:00 2026] [::1]:55154 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:00 2026] [::1]:55178 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55164 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55178 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55138 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55154 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55164 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55178 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55182 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55182 [200]: GET /
+[Thu Feb 19 03:42:00 2026] [::1]:55182 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55198 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55214 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55216 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55198 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:00 2026] [::1]:55214 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:00 2026] [::1]:55198 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55214 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55216 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:00 2026] [::1]:55216 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55218 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55218 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:00 2026] [::1]:55218 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55222 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55230 Accepted
+[Thu Feb 19 03:42:00 2026] [::1]:55222 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:00 2026] [::1]:55222 Closing
+[Thu Feb 19 03:42:00 2026] [::1]:55230 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:00 2026] [::1]:55230 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55236 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55236 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:01 2026] [::1]:55236 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55250 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55258 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55260 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55262 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55264 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55250 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:01 2026] [::1]:55250 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55258 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:01 2026] [::1]:55258 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55260 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:01 2026] [::1]:55260 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55262 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55262 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55264 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55264 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55268 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55274 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55282 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55286 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55268 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55268 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55274 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55274 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55282 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55282 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55286 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:01 2026] [::1]:55286 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55298 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55298 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55298 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55306 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55308 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55324 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55306 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55308 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:01 2026] [::1]:55324 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:01 2026] [::1]:55306 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55308 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55324 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55328 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55342 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55328 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55342 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:01 2026] [::1]:55328 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55342 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55344 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55344 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55344 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55350 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55350 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55350 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55362 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55376 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55384 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55388 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55398 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55362 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:01 2026] [::1]:55362 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55376 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:01 2026] [::1]:55384 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:01 2026] [::1]:55388 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:01 2026] [::1]:55398 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55376 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55384 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55388 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55398 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55402 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55402 [200]: GET /
+[Thu Feb 19 03:42:01 2026] [::1]:55402 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55412 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55428 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55436 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55412 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:01 2026] [::1]:55428 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:01 2026] [::1]:55412 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55428 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55436 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:01 2026] [::1]:55436 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55452 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55452 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:01 2026] [::1]:55452 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55464 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55474 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55464 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:01 2026] [::1]:55464 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55474 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55474 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55486 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55498 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55486 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:01 2026] [::1]:55502 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55498 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:01 2026] [::1]:55506 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55502 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:01 2026] [::1]:55486 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55506 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:01 2026] [::1]:55498 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55502 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55506 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55508 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55510 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55508 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55510 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55508 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55510 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55514 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55528 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55540 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55548 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55514 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55514 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55528 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55528 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55540 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55548 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:01 2026] [::1]:55540 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55548 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55560 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55560 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55560 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55570 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55570 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55570 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55572 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55572 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:01 2026] [::1]:55572 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55584 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55592 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55596 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55600 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55604 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55606 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55584 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:01 2026] [::1]:55584 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55592 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55592 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55596 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:01 2026] [::1]:55596 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55600 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55600 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55604 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:01 2026] [::1]:55604 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55606 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:01 2026] [::1]:55606 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55614 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55628 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55640 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55646 Accepted
+[Thu Feb 19 03:42:01 2026] [::1]:55614 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:01 2026] [::1]:55614 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55628 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:01 2026] [::1]:55628 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55640 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55640 Closing
+[Thu Feb 19 03:42:01 2026] [::1]:55646 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:01 2026] [::1]:55646 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55650 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55650 [200]: GET /
+[Thu Feb 19 03:42:02 2026] [::1]:55650 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55660 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55676 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55682 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55660 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:02 2026] [::1]:55660 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55676 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:02 2026] [::1]:55682 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:02 2026] [::1]:55676 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55682 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55698 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55698 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:02 2026] [::1]:55698 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55702 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55712 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55702 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:02 2026] [::1]:55712 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55702 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55712 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55722 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55724 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55730 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55740 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55722 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:02 2026] [::1]:55724 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:02 2026] [::1]:55722 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55730 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:02 2026] [::1]:55724 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55730 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55740 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:02 2026] [::1]:55740 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55756 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55770 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55780 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55756 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55770 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55782 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55756 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55770 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55788 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55802 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55780 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55782 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55780 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55782 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55788 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55788 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55802 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:02 2026] [::1]:55802 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55804 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55804 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55804 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55818 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55820 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55818 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55820 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:02 2026] [::1]:55818 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55820 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55824 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55824 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:02 2026] [::1]:55824 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55830 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55830 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55830 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55846 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55850 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55852 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55846 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:02 2026] [::1]:55850 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55846 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55850 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55852 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:02 2026] [::1]:55852 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55860 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55860 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55860 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55872 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55878 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55888 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55900 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55872 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:02 2026] [::1]:55878 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:02 2026] [::1]:55888 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:02 2026] [::1]:55872 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55878 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55888 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55900 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55900 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55916 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55916 [200]: GET /
+[Thu Feb 19 03:42:02 2026] [::1]:55916 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55920 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55932 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55936 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55920 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:02 2026] [::1]:55920 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55932 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:02 2026] [::1]:55936 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:02 2026] [::1]:55932 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55936 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55946 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55946 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:02 2026] [::1]:55946 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55954 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55962 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55954 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:02 2026] [::1]:55962 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:55954 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55962 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55968 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55980 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55986 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:56002 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:55968 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:02 2026] [::1]:55980 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:02 2026] [::1]:55986 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:02 2026] [::1]:56002 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:02 2026] [::1]:55968 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55980 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:55986 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:56002 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:56016 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:56032 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:56016 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:56032 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:56016 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:56032 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:56036 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:56046 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:56054 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:56070 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:56036 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:56036 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:56046 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:56046 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:56054 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:56054 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:56070 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:02 2026] [::1]:56070 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:56078 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:56078 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:56078 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:56092 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:56100 Accepted
+[Thu Feb 19 03:42:02 2026] [::1]:56092 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:02 2026] [::1]:56100 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:02 2026] [::1]:56092 Closing
+[Thu Feb 19 03:42:02 2026] [::1]:56100 Closing
+[Thu Feb 19 03:42:03 2026] [::1]:56106 Accepted
+[Thu Feb 19 03:42:03 2026] [::1]:56116 Accepted
+[Thu Feb 19 03:42:03 2026] [::1]:56132 Accepted
+[Thu Feb 19 03:42:03 2026] [::1]:56142 Accepted
+[Thu Feb 19 03:42:03 2026] [::1]:56144 Accepted
+[Thu Feb 19 03:42:03 2026] [::1]:56154 Accepted
+[Thu Feb 19 03:42:03 2026] [::1]:56106 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:03 2026] [::1]:56106 Closing
+[Thu Feb 19 03:42:03 2026] [::1]:56116 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:03 2026] [::1]:56116 Closing
+[Thu Feb 19 03:42:03 2026] [::1]:56132 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:03 2026] [::1]:56132 Closing
+[Thu Feb 19 03:42:03 2026] [::1]:56142 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:03 2026] [::1]:56142 Closing
+[Thu Feb 19 03:42:03 2026] [::1]:56144 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:03 2026] [::1]:56154 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:03 2026] [::1]:56144 Closing
+[Thu Feb 19 03:42:03 2026] [::1]:56154 Closing
+[Thu Feb 19 03:42:03 2026] [::1]:56164 Accepted
+[Thu Feb 19 03:42:03 2026] [::1]:56176 Accepted
+[Thu Feb 19 03:42:03 2026] [::1]:56164 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:03 2026] [::1]:56192 Accepted
+[Thu Feb 19 03:42:03 2026] [::1]:56176 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:03 2026] [::1]:56192 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:03 2026] [::1]:56164 Closing
+[Thu Feb 19 03:42:03 2026] [::1]:56176 Closing
+[Thu Feb 19 03:42:03 2026] [::1]:56192 Closing
+[Thu Feb 19 03:42:03 2026] [::1]:56198 Accepted
+[Thu Feb 19 03:42:03 2026] [::1]:56198 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:03 2026] [::1]:56198 Closing
+[Thu Feb 19 03:42:03 2026] [::1]:56200 Accepted
+[Thu Feb 19 03:42:03 2026] [::1]:56200 [200]: GET /api.php?resource=reviews
+[Thu Feb 19 03:42:03 2026] [::1]:56200 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56202 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56202 [200]: GET /
+[Thu Feb 19 03:42:05 2026] [::1]:56202 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56208 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56212 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56222 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56208 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:05 2026] [::1]:56212 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:05 2026] [::1]:56208 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56212 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56222 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:05 2026] [::1]:56222 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56238 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56238 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:05 2026] [::1]:56238 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56244 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56256 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56244 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:05 2026] [::1]:56256 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56244 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56256 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56262 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56276 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56262 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:05 2026] [::1]:56278 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56276 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:05 2026] [::1]:56282 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56278 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:05 2026] [::1]:56262 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56282 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:05 2026] [::1]:56276 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56278 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56282 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56290 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56292 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56290 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56292 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56290 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56292 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56298 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56310 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56322 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56338 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56298 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56310 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56298 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56310 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56322 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56322 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56338 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:05 2026] [::1]:56338 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56352 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56352 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56352 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56354 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56354 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56354 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56370 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56376 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56370 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:05 2026] [::1]:56390 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56376 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:05 2026] [::1]:56400 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56390 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56370 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56400 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:05 2026] [::1]:56376 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56390 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56400 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56406 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56406 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56406 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56408 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56410 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56418 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56432 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56438 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56408 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:05 2026] [::1]:56408 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56410 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:05 2026] [::1]:56418 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:05 2026] [::1]:56432 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:05 2026] [::1]:56438 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56410 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56418 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56432 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56438 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56446 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56446 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56446 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56448 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56448 [200]: GET /
+[Thu Feb 19 03:42:05 2026] [::1]:56448 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56460 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56466 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56470 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56460 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:05 2026] [::1]:56460 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56466 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:05 2026] [::1]:56466 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56470 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:05 2026] [::1]:56470 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56478 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56478 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:05 2026] [::1]:56478 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56488 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56492 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56488 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:05 2026] [::1]:56492 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56488 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56492 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56502 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56502 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:05 2026] [::1]:56502 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56512 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56520 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56530 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56536 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56538 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56512 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:05 2026] [::1]:56512 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56520 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:05 2026] [::1]:56530 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:05 2026] [::1]:56536 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:05 2026] [::1]:56520 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56530 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56536 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56540 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56538 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56538 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56546 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56550 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56554 Accepted
+[Thu Feb 19 03:42:05 2026] [::1]:56540 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56540 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56546 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56550 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56554 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:05 2026] [::1]:56546 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56550 Closing
+[Thu Feb 19 03:42:05 2026] [::1]:56554 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56556 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56556 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56556 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56560 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56568 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56560 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56568 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:06 2026] [::1]:56560 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56568 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56576 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56580 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56576 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:06 2026] [::1]:56576 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56580 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56580 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56596 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56602 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56612 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56596 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:06 2026] [::1]:56602 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56622 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56612 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:06 2026] [::1]:56634 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56622 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:06 2026] [::1]:56596 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56602 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56634 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:06 2026] [::1]:56612 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56622 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56634 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56644 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56654 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56644 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:06 2026] [::1]:56662 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56654 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56662 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56644 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56654 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56662 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56674 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56674 [200]: GET /
+[Thu Feb 19 03:42:06 2026] [::1]:56674 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56682 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56686 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56694 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56682 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:06 2026] [::1]:56686 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:06 2026] [::1]:56694 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:06 2026] [::1]:56682 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56686 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56694 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56702 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56702 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:06 2026] [::1]:56702 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56710 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56710 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:06 2026] [::1]:56710 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56716 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56716 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56716 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56728 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56742 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56748 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56728 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:06 2026] [::1]:56742 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:06 2026] [::1]:56728 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56748 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:06 2026] [::1]:56742 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56748 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56754 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56766 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56768 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56778 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56784 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56796 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56754 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:06 2026] [::1]:56754 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56766 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56768 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56766 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56768 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56778 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56778 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56784 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56784 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56796 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56796 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56798 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56798 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:06 2026] [::1]:56798 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56802 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56802 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56802 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56812 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56812 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56812 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56818 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56832 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56818 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:06 2026] [::1]:56838 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56832 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:06 2026] [::1]:56852 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56838 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56862 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56818 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56852 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:06 2026] [::1]:56864 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56832 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56862 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56864 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:06 2026] [::1]:56838 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56852 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56862 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56864 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56874 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56878 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56884 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56900 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56874 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:06 2026] [::1]:56878 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:06 2026] [::1]:56884 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:06 2026] [::1]:56900 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56874 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56878 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56884 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56900 Closing
+[Thu Feb 19 03:42:06 2026] [::1]:56908 Accepted
+[Thu Feb 19 03:42:06 2026] [::1]:56908 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:06 2026] [::1]:56908 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:56912 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:56912 [200]: GET /
+[Thu Feb 19 03:42:07 2026] [::1]:56912 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:56924 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:56936 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:56924 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:07 2026] [::1]:56936 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:07 2026] [::1]:56924 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:56936 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:56938 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:56938 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:07 2026] [::1]:56938 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:56946 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:56946 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:07 2026] [::1]:56946 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:56960 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:56960 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:07 2026] [::1]:56960 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:56962 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:56962 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:56962 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:56974 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:56980 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:56994 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57002 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:56974 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:07 2026] [::1]:56980 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:07 2026] [::1]:56994 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:07 2026] [::1]:57002 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:07 2026] [::1]:56974 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:56980 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:56994 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57002 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57012 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57026 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57012 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:57012 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57026 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:57026 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57042 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57058 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57062 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57078 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57042 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:57042 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57058 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:57058 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57062 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:57062 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57078 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:07 2026] [::1]:57078 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57082 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57082 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:57082 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57090 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57098 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57106 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57112 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57120 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57128 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57090 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:07 2026] [::1]:57098 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:57106 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:57112 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:07 2026] [::1]:57120 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:07 2026] [::1]:57128 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:57090 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57098 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57106 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57112 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57120 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57128 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57130 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57146 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57130 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:07 2026] [::1]:57162 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57146 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:07 2026] [::1]:57164 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57162 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:07 2026] [::1]:57180 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57130 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57164 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:07 2026] [::1]:57146 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57180 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:57162 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57164 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57180 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57188 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57188 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:07 2026] [::1]:57188 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57200 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57200 [200]: GET /terminos.html
+[Thu Feb 19 03:42:07 2026] [::1]:57200 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57216 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57218 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57216 [200]: GET /legal.css
+[Thu Feb 19 03:42:07 2026] [::1]:57216 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57218 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:07 2026] [::1]:57218 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57222 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57222 [200]: GET /terminos.html
+[Thu Feb 19 03:42:07 2026] [::1]:57222 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57228 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57238 Accepted
+[Thu Feb 19 03:42:07 2026] [::1]:57228 [200]: GET /legal.css
+[Thu Feb 19 03:42:07 2026] [::1]:57228 Closing
+[Thu Feb 19 03:42:07 2026] [::1]:57238 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:07 2026] [::1]:57238 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57246 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57246 [200]: GET /terminos.html
+[Thu Feb 19 03:42:08 2026] [::1]:57246 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57252 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57266 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57252 [200]: GET /legal.css
+[Thu Feb 19 03:42:08 2026] [::1]:57266 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:08 2026] [::1]:57252 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57266 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57272 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57272 [200]: GET /index.html
+[Thu Feb 19 03:42:08 2026] [::1]:57272 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57282 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57294 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57282 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:08 2026] [::1]:57282 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57300 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57294 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:08 2026] [::1]:57294 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57300 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:08 2026] [::1]:57300 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57308 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57308 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:08 2026] [::1]:57308 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57324 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57334 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57324 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:08 2026] [::1]:57324 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57334 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57334 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57346 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57346 [200]: GET /terminos.html
+[Thu Feb 19 03:42:08 2026] [::1]:57346 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57350 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57354 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57368 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57384 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57400 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57410 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57400 [200]: GET /legal.css
+[Thu Feb 19 03:42:08 2026] [::1]:57400 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57420 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57426 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57410 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:08 2026] [::1]:57410 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57350 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:08 2026] [::1]:57350 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57354 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:08 2026] [::1]:57368 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:08 2026] [::1]:57384 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:08 2026] [::1]:57420 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:08 2026] [::1]:57426 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57354 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57368 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57384 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57420 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57426 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57428 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57442 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57428 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57428 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57448 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57462 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57442 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57442 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57448 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57448 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57462 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57462 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57478 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57478 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57478 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57494 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57508 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57494 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57522 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57508 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:08 2026] [::1]:57522 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:08 2026] [::1]:57494 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57508 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57522 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57530 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57538 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57530 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57542 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57538 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:08 2026] [::1]:57542 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57530 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57538 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57542 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57544 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57550 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57552 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57554 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57544 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:08 2026] [::1]:57550 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:08 2026] [::1]:57552 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:08 2026] [::1]:57554 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:08 2026] [::1]:57544 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57550 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57552 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57554 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57566 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57566 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57566 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57580 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57584 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57580 [200]: GET /privacidad.html
+[Thu Feb 19 03:42:08 2026] [::1]:57584 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:08 2026] [::1]:57580 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57584 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57596 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57596 [200]: GET /legal.css
+[Thu Feb 19 03:42:08 2026] [::1]:57596 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57612 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57612 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:08 2026] [::1]:57612 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57618 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57618 [200]: GET /privacidad.html
+[Thu Feb 19 03:42:08 2026] [::1]:57618 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57624 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57624 [200]: GET /legal.css
+[Thu Feb 19 03:42:08 2026] [::1]:57624 Closing
+[Thu Feb 19 03:42:08 2026] [::1]:57636 Accepted
+[Thu Feb 19 03:42:08 2026] [::1]:57636 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:08 2026] [::1]:57636 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57652 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57652 [200]: GET /index.html
+[Thu Feb 19 03:42:09 2026] [::1]:57652 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57664 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57666 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57664 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:09 2026] [::1]:57666 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:09 2026] [::1]:57664 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57666 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57672 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57672 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:09 2026] [::1]:57672 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57686 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57686 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:09 2026] [::1]:57686 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57700 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57712 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57700 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:09 2026] [::1]:57700 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57712 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57712 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57728 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57728 [200]: GET /privacidad.html
+[Thu Feb 19 03:42:09 2026] [::1]:57728 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57738 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57740 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57738 [200]: GET /legal.css
+[Thu Feb 19 03:42:09 2026] [::1]:57740 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:09 2026] [::1]:57738 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57740 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57746 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57762 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57772 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57786 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57798 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57810 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57746 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:09 2026] [::1]:57762 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:09 2026] [::1]:57772 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:09 2026] [::1]:57746 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57762 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57772 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57786 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:09 2026] [::1]:57786 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57798 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57810 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57798 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57810 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57816 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57832 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57816 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57834 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57832 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57836 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57834 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57816 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57836 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:09 2026] [::1]:57832 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57834 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57836 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57840 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57840 [200]: GET /privacidad.html
+[Thu Feb 19 03:42:09 2026] [::1]:57840 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57842 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57848 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57842 [200]: GET /legal.css
+[Thu Feb 19 03:42:09 2026] [::1]:57848 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:09 2026] [::1]:57842 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57848 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57856 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57856 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57856 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57868 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57882 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57868 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57882 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:09 2026] [::1]:57868 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57882 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57888 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57892 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57888 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:09 2026] [::1]:57892 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57888 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57892 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57908 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57912 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57928 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57934 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57908 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:09 2026] [::1]:57912 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57928 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:09 2026] [::1]:57908 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57912 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57928 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57934 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:09 2026] [::1]:57934 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57942 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57948 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57942 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:09 2026] [::1]:57942 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57948 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:09 2026] [::1]:57948 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57950 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57950 [200]: GET /api.php?resource=availability
+[Thu Feb 19 03:42:09 2026] [::1]:57950 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57962 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57962 [200]: GET /api.php?resource=booked-slots&date=2026-02-21&doctor=rosero
+[Thu Feb 19 03:42:09 2026] [::1]:57962 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57968 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57968 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57968 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:57974 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:57974 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:09 2026] [::1]:57974 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:52168 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:52168 [200]: GET /cookies.html
+[Thu Feb 19 03:42:09 2026] [::1]:52168 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:52174 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:52186 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:52174 [200]: GET /legal.css
+[Thu Feb 19 03:42:09 2026] [::1]:52174 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:52186 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:09 2026] [::1]:52186 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:52198 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:52206 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:52198 [200]: GET /images/optimized/service-consulta.avif
+[Thu Feb 19 03:42:09 2026] [::1]:52206 [200]: GET /images/optimized/service-telemedicina.avif
+[Thu Feb 19 03:42:09 2026] [::1]:52198 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:52206 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:52214 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:52228 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:52242 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:52254 Accepted
+[Thu Feb 19 03:42:09 2026] [::1]:52214 [200]: GET /images/optimized/service-laser.avif
+[Thu Feb 19 03:42:09 2026] [::1]:52228 [200]: GET /images/optimized/service-rejuvenecimiento.avif
+[Thu Feb 19 03:42:09 2026] [::1]:52242 [200]: GET /images/optimized/service-acne.avif
+[Thu Feb 19 03:42:09 2026] [::1]:52254 [200]: GET /images/optimized/service-cancer.avif
+[Thu Feb 19 03:42:09 2026] [::1]:52214 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:52228 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:52242 Closing
+[Thu Feb 19 03:42:09 2026] [::1]:52254 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52266 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52278 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52266 [200]: GET /images/optimized/team-rosero.avif
+[Thu Feb 19 03:42:10 2026] [::1]:52266 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52278 [200]: GET /images/optimized/team-narvaez.avif
+[Thu Feb 19 03:42:10 2026] [::1]:52278 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52294 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52294 [200]: GET /cookies.html
+[Thu Feb 19 03:42:10 2026] [::1]:52294 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52308 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52308 [200]: GET /legal.css
+[Thu Feb 19 03:42:10 2026] [::1]:52308 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52312 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52312 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:10 2026] [::1]:52312 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52318 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52318 [200]: GET /api.php?resource=reviews
+[Thu Feb 19 03:42:10 2026] [::1]:52318 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52324 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52324 [200]: GET /cookies.html
+[Thu Feb 19 03:42:10 2026] [::1]:52324 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52340 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52352 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52340 [200]: GET /legal.css
+[Thu Feb 19 03:42:10 2026] [::1]:52352 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:10 2026] [::1]:52340 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52352 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52354 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52354 [200]: GET /cookies.html
+[Thu Feb 19 03:42:10 2026] [::1]:52354 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52364 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52364 [200]: GET /legal.css
+[Thu Feb 19 03:42:10 2026] [::1]:52364 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52366 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52366 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:10 2026] [::1]:52366 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52376 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52376 [200]: GET /aviso-medico.html
+[Thu Feb 19 03:42:10 2026] [::1]:52376 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52380 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52396 Accepted
+[Thu Feb 19 03:42:10 2026] [::1]:52380 [200]: GET /legal.css
+[Thu Feb 19 03:42:10 2026] [::1]:52396 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:10 2026] [::1]:52380 Closing
+[Thu Feb 19 03:42:10 2026] [::1]:52396 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52402 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52402 [200]: GET /aviso-medico.html
+[Thu Feb 19 03:42:11 2026] [::1]:52402 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52404 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52408 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52404 [200]: GET /legal.css
+[Thu Feb 19 03:42:11 2026] [::1]:52408 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:11 2026] [::1]:52404 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52408 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52416 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52416 [200]: GET /aviso-medico.html
+[Thu Feb 19 03:42:11 2026] [::1]:52416 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52422 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52424 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52422 [200]: GET /legal.css
+[Thu Feb 19 03:42:11 2026] [::1]:52424 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:11 2026] [::1]:52422 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52424 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52432 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52432 [200]: GET /api.php?resource=availability
+[Thu Feb 19 03:42:11 2026] [::1]:52432 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52442 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52442 [200]: GET /index.html
+[Thu Feb 19 03:42:11 2026] [::1]:52442 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52448 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52452 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52448 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:11 2026] [::1]:52460 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52452 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:11 2026] [::1]:52460 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:11 2026] [::1]:52448 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52452 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52460 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52464 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52464 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:11 2026] [::1]:52464 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52478 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52478 [200]: GET /aviso-medico.html
+[Thu Feb 19 03:42:11 2026] [::1]:52478 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52494 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52502 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52494 [200]: GET /legal.css
+[Thu Feb 19 03:42:11 2026] [::1]:52494 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52502 [200]: GET /legal-i18n.js
+[Thu Feb 19 03:42:11 2026] [::1]:52502 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52508 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52508 [200]: GET /?reschedule=token_invalido_123
+[Thu Feb 19 03:42:11 2026] [::1]:52508 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52514 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52528 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52542 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52514 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:11 2026] [::1]:52514 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52528 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:11 2026] [::1]:52528 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52542 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:11 2026] [::1]:52542 Closing
+[Thu Feb 19 03:42:11 2026] [::1]:52552 Accepted
+[Thu Feb 19 03:42:11 2026] [::1]:52552 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:11 2026] [::1]:52552 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55700 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55716 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55700 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:31 2026] [::1]:55716 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55700 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55716 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55724 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55724 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:31 2026] [::1]:55724 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55732 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55744 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55754 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55760 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55732 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:31 2026] [::1]:55744 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:31 2026] [::1]:55754 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:31 2026] [::1]:55766 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55760 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55768 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55766 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55732 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55744 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55754 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55760 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55766 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55768 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55768 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55778 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55790 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55800 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55778 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55790 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55778 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55790 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55800 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:31 2026] [::1]:55800 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55804 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55804 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55804 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55806 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55822 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55806 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55822 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:31 2026] [::1]:55806 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55822 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55834 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55844 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55860 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55862 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55870 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55834 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:31 2026] [::1]:55844 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55860 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:31 2026] [::1]:55862 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55878 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55870 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:31 2026] [::1]:55878 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:31 2026] [::1]:55834 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55844 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55860 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55862 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55870 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55878 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55888 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55898 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55888 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:31 2026] [::1]:55914 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55898 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:31 2026] [::1]:55914 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55888 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55898 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55914 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55920 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55920 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55920 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55936 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55952 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55962 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55978 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55986 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55990 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55936 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:31 2026] [::1]:55952 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:31 2026] [::1]:55936 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55952 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55962 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:31 2026] [::1]:55978 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:31 2026] [::1]:55986 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:31 2026] [::1]:55990 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:55962 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55978 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55986 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55990 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:55996 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56006 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56022 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55996 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:56006 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:56028 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56022 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:56044 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56028 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:56054 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:55996 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56006 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56044 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:56022 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56054 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:31 2026] [::1]:56028 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56044 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56054 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56066 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56066 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:56066 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56080 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56080 [200]: GET /reschedule-engine.js?v=figo-reschedule-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:31 2026] [::1]:56080 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56090 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56106 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56090 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:56106 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:31 2026] [::1]:56090 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56106 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56110 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56114 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56110 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:31 2026] [::1]:56120 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56114 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:56122 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56120 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:31 2026] [::1]:56136 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56110 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56122 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:56150 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56114 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56136 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:31 2026] [::1]:56150 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:31 2026] [::1]:56120 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56122 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56136 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56150 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56158 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56170 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56172 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56158 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:31 2026] [::1]:56170 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:31 2026] [::1]:56172 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:56158 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56170 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56172 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56184 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56184 [404]: GET /api.php?resource=reschedule&token=token_invalido_123
+[Thu Feb 19 03:42:31 2026] [::1]:56184 Closing
+[Thu Feb 19 03:42:31 2026] [::1]:56192 Accepted
+[Thu Feb 19 03:42:31 2026] [::1]:56192 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:31 2026] [::1]:56192 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56208 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56208 [200]: GET /
+[Thu Feb 19 03:42:34 2026] [::1]:56208 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56212 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56224 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56212 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:34 2026] [::1]:56234 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56224 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:34 2026] [::1]:56234 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:34 2026] [::1]:56212 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56224 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56234 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56240 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56240 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:34 2026] [::1]:56240 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56244 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56244 [200]: GET /index.html
+[Thu Feb 19 03:42:34 2026] [::1]:56244 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56252 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56254 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56252 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:34 2026] [::1]:56254 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56252 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56254 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56268 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56272 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56288 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56268 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:42:34 2026] [::1]:56272 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:42:34 2026] [::1]:56288 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:42:34 2026] [::1]:56268 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56272 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56288 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56302 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56302 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:42:34 2026] [::1]:56302 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56308 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56314 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56328 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56330 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56344 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56308 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:34 2026] [::1]:56314 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:34 2026] [::1]:56308 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56328 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:34 2026] [::1]:56314 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56328 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56330 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:34 2026] [::1]:56330 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56344 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:34 2026] [::1]:56344 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56356 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56364 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56356 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56356 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56368 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56384 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56392 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56364 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56368 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56364 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56368 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56384 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56392 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56384 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56392 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56400 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56412 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56400 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:42:34 2026] [::1]:56412 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56400 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56412 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56426 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56432 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56448 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56456 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56426 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:42:34 2026] [::1]:56426 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56462 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56432 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:42:34 2026] [::1]:56448 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:42:34 2026] [::1]:56456 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:42:34 2026] [::1]:56472 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56462 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56480 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56472 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56432 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56448 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56456 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56480 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56462 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56472 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56480 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56482 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56492 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56502 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56482 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56492 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56502 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:42:34 2026] [::1]:56482 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56492 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56502 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56510 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56510 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56510 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56518 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56518 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56518 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56522 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56522 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:34 2026] [::1]:56522 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56526 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56526 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56526 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56536 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56536 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56536 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56546 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56546 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56546 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56548 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56548 [200]: GET /api.php?resource=reviews
+[Thu Feb 19 03:42:34 2026] [::1]:56548 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56552 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56558 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56570 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56576 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56552 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:34 2026] [::1]:56558 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:34 2026] [::1]:56552 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56558 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56570 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56570 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56576 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:34 2026] [::1]:56576 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56590 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56590 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56590 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56596 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56596 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:34 2026] [::1]:56596 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56606 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56610 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56606 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:34 2026] [::1]:56610 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:34 2026] [::1]:56606 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56610 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56624 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56624 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56624 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56636 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56648 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56652 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56636 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:42:34 2026] [::1]:56636 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56648 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:42:34 2026] [::1]:56648 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56652 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56652 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56658 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56672 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56658 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:42:34 2026] [::1]:56688 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56672 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56702 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56688 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56714 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56658 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56702 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:42:34 2026] [::1]:56672 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56714 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:42:34 2026] [::1]:56688 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56702 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56714 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56720 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56720 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:42:34 2026] [::1]:56720 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56722 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56722 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:42:34 2026] [::1]:56722 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56724 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56724 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:42:34 2026] [::1]:56724 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56738 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56738 [400]: GET /api.php?resource=reschedule&token=
+[Thu Feb 19 03:42:34 2026] [::1]:56738 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56752 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56752 [404]: GET /api.php?resource=reschedule&token=abcdef1234567890abcdef1234567890
+[Thu Feb 19 03:42:34 2026] [::1]:56752 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56768 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56768 [200]: GET /figo-chat.php
+[Thu Feb 19 03:42:34 2026] [::1]:56768 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56776 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56776 [400]: PATCH /api.php?resource=reschedule
+[Thu Feb 19 03:42:34 2026] [::1]:56776 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56782 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56782 [404]: GET /data/ - No such file or directory
+[Thu Feb 19 03:42:34 2026] [::1]:56782 Closing
+[Thu Feb 19 03:42:34 2026] [::1]:56786 Accepted
+[Thu Feb 19 03:42:34 2026] [::1]:56786 [404]: GET /uploads/ - No such file or directory
+[Thu Feb 19 03:42:34 2026] [::1]:56786 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52260 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52260 [200]: GET /
+[Thu Feb 19 03:43:17 2026] [::1]:52260 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52264 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52266 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52280 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52264 [200]: GET /styles.css?v=ui-20260219-critical2-mobiletypelock1-a11yfocus1-perfcv1
+[Thu Feb 19 03:43:17 2026] [::1]:52264 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52266 [200]: GET /styles-deferred.css?v=ui-20260219-deferred12-cspinline1-stateclass1
+[Thu Feb 19 03:43:17 2026] [::1]:52280 [200]: GET /hero-woman.jpg
+[Thu Feb 19 03:43:17 2026] [::1]:52266 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52280 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52292 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52292 [200]: GET /script.js?v=figo-20260218-phase5-opt-i18n2-ui2-gallery1-reschedule1-bookingui1-chatbooking1-successmodal1-engagement1-modalux1-loaderconsolidation1-warmupconsolidation1-observerconsolidation1-wrapperconsolidation1-bootdefer1-apihardening1-uploadretry1-analytics2-uploadparallel1-transferretry2-linkrel1-textclean1-placeholderlinks1-a11yfocus1-deferredsync1-chathardening1-depuracionjs6-cspinline1-dataenginewrap1-chatui1-actionrouter1-i18nengine1-themeengine1-consentengine1-analyticsengine1-chatwidget1-chatui2-reschedulegateway1-bootstrapengine1-loaderfactory1-warmupbatch1-bootstrapevents1-uibridge2-chatstate1
+[Thu Feb 19 03:43:17 2026] [::1]:52292 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52296 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52296 [200]: GET /app-bootstrap-engine.js?v=figo-bootstrap-20260219-phase2-events1
+[Thu Feb 19 03:43:17 2026] [::1]:52296 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52312 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52312 [200]: GET /chat-state-engine.js?v=figo-chat-state-20260219-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52312 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52320 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52328 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52336 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52346 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52320 [200]: GET /images/optimized/showcase-hero.avif
+[Thu Feb 19 03:43:17 2026] [::1]:52328 [200]: GET /images/optimized/showcase-diagnostic.avif
+[Thu Feb 19 03:43:17 2026] [::1]:52320 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52328 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52336 [200]: GET /images/optimized/showcase-clinic.avif
+[Thu Feb 19 03:43:17 2026] [::1]:52336 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52348 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52364 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52346 [200]: GET /images/optimized/showcase-treatment.avif
+[Thu Feb 19 03:43:17 2026] [::1]:52346 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52372 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52348 [200]: GET /action-router-engine.js?v=figo-action-router-20260219-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52364 [200]: GET /theme-engine.js?v=figo-theme-20260219-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52384 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52348 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52364 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52398 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52408 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52372 [200]: GET /i18n-engine.js?v=figo-i18n-20260219-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52384 [200]: GET /consent-engine.js?v=figo-consent-20260219-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52372 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52384 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52398 [200]: GET /analytics-engine.js?v=figo-analytics-20260219-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52398 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52408 [200]: GET /chat-widget-engine.js?v=figo-chat-widget-20260219-phase2-notification1
+[Thu Feb 19 03:43:17 2026] [::1]:52408 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52412 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52412 [200]: GET /reschedule-gateway-engine.js?v=figo-reschedule-gateway-20260219-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52412 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52422 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52426 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52422 [200]: GET /data-engine.js?v=figo-data-20260219-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52426 [200]: GET /booking-engine.js?v=figo-booking-20260218-phase1-analytics2-transferretry2-stateclass1
+[Thu Feb 19 03:43:17 2026] [::1]:52422 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52426 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52440 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52440 [200]: GET /booking-ui.js?v=figo-booking-ui-20260218-phase4-stateclass1
+[Thu Feb 19 03:43:17 2026] [::1]:52440 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52446 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52452 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52446 [200]: GET /reviews-engine.js?v=figo-reviews-20260219-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52454 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52452 [200]: GET /gallery-interactions.js?v=figo-gallery-20260218-phase4
+[Thu Feb 19 03:43:17 2026] [::1]:52466 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52454 [200]: GET /chat-ui-engine.js?v=figo-chat-ui-20260219-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52446 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52466 [200]: GET /chat-engine.js?v=figo-chat-20260219-phase3-runtimeconfig1-contextcap1
+[Thu Feb 19 03:43:17 2026] [::1]:52452 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52454 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52466 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52474 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52474 [200]: GET /chat-booking-engine.js?v=figo-chat-booking-20260219-phase2-inlinefix1
+[Thu Feb 19 03:43:17 2026] [::1]:52474 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52488 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52500 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52488 [200]: GET /ui-effects.js?v=figo-ui-20260218-phase4
+[Thu Feb 19 03:43:17 2026] [::1]:52502 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52500 [200]: GET /success-modal-engine.js?v=figo-success-modal-20260218-phase1-inlineclass1
+[Thu Feb 19 03:43:17 2026] [::1]:52506 Accepted
+[Thu Feb 19 03:43:17 2026] [::1]:52488 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52500 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52502 [200]: GET /engagement-forms-engine.js?v=figo-engagement-20260218-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52502 Closing
+[Thu Feb 19 03:43:17 2026] [::1]:52506 [200]: GET /modal-ux-engine.js?v=figo-modal-ux-20260218-phase1
+[Thu Feb 19 03:43:17 2026] [::1]:52506 Closing

--- a/styles-deferred.css
+++ b/styles-deferred.css
@@ -278,8 +278,8 @@ html[data-theme='dark'] .theme-btn[data-theme-mode='system'] i {
 
 .section-gray {
     background:
-        radial-gradient(560px 260px at 12% 0%, rgba(69, 143, 255, 0.12), transparent 70%),
-        linear-gradient(180deg, #f6f9ff 0%, #edf3fd 100%);
+        radial-gradient(560px 260px at 12% 0%, rgba(14, 165, 233, 0.08), transparent 70%),
+        linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
 }
 
 .section-dark {
@@ -2774,13 +2774,13 @@ html[data-theme='dark'] .toast-message {
 }
 
 html[data-theme='light'] .hero {
-    background: linear-gradient(180deg, #fbfbfd 0%, #f5f5f7 100%) !important;
+    background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%) !important;
 }
 
 html[data-theme='light'] .hero::before {
     background:
-        radial-gradient(560px 260px at 22% 4%, rgba(0, 113, 227, 0.14), transparent 70%),
-        radial-gradient(520px 250px at 86% 84%, rgba(73, 176, 255, 0.12), transparent 72%) !important;
+        radial-gradient(560px 260px at 22% 4%, rgba(2, 132, 199, 0.08), transparent 70%),
+        radial-gradient(520px 250px at 86% 84%, rgba(56, 189, 248, 0.08), transparent 72%) !important;
 }
 
 html[data-theme='light'] .hero-bg-image {
@@ -2789,19 +2789,19 @@ html[data-theme='light'] .hero-bg-image {
 }
 
 html[data-theme='light'] .hero-title {
-    color: #1d1d1f !important;
+    color: #1e293b !important;
     text-shadow: none !important;
 }
 
 html[data-theme='light'] .hero-subtitle {
-    color: #424245 !important;
+    color: #475569 !important;
     text-shadow: none !important;
 }
 
 html[data-theme='light'] .contact-chip {
     border-color: rgba(0, 0, 0, 0.1) !important;
     background: rgba(255, 255, 255, 0.92) !important;
-    color: #1d1d1f !important;
+    color: #1e293b !important;
 }
 
 html[data-theme='light'] .contact-chip:hover {
@@ -2810,7 +2810,7 @@ html[data-theme='light'] .contact-chip:hover {
 }
 
 html[data-theme='light'] .contact-chip.whatsapp {
-    color: #1d1d1f !important;
+    color: #1e293b !important;
 }
 
 html[data-theme='light'] .metric-card {
@@ -2819,11 +2819,11 @@ html[data-theme='light'] .metric-card {
 }
 
 html[data-theme='light'] .metric-card strong {
-    color: #1d1d1f !important;
+    color: #1e293b !important;
 }
 
 html[data-theme='light'] .metric-card span {
-    color: #6e6e73 !important;
+    color: #64748b !important;
 }
 
 html[data-theme='dark'] .hero {

--- a/styles.css
+++ b/styles.css
@@ -5,15 +5,15 @@
    ======================================== */
 
 :root {
-    --ui-ink: #1d1d1f;
-    --ui-ink-soft: #5f6673;
-    --ui-bg: #f5f5f7;
+    --ui-ink: #1e293b;
+    --ui-ink-soft: #64748b;
+    --ui-bg: #f8fafc;
     --ui-surface: #ffffff;
-    --ui-surface-soft: #eef3fb;
-    --ui-border: #d2d2d7;
-    --ui-border-strong: #bfcee7;
-    --ui-accent: #0a84ff;
-    --ui-accent-2: #3aa0ff;
+    --ui-surface-soft: #f1f5f9;
+    --ui-border: #e2e8f0;
+    --ui-border-strong: #cbd5e1;
+    --ui-accent: #0284c7;
+    --ui-accent-2: #38bdf8;
     --ui-success: #25b16a;
     --ui-dark: #0d1728;
     --ui-dark-2: #17263d;
@@ -53,7 +53,7 @@ body {
     line-height: 1.5;
     min-height: 100vh;
     overflow-x: hidden;
-    background: linear-gradient(180deg, #fbfbfd 0%, #f5f5f7 100%);
+    background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
Updated `styles.css` variables and `styles-deferred.css` overrides to implement a cleaner, more professional "Medical Clean" color palette for light mode. Replaced the previous blue-gray background gradients with neutral Slate 50/100 tones and improved text contrast with Slate 800/500. Updated the Hero section and `.section-gray` to align with the new design system.

---
*PR created automatically by Jules for task [4534269691204401441](https://jules.google.com/task/4534269691204401441) started by @erosero558558*