### PR TITLE
Implement PDO, HTTP security headers, and password hashing support

### DIFF
--- a/admin-auth.php
+++ b/admin-auth.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/api-lib.php';
 
+apply_security_headers(false);
 api_apply_cors(['GET', 'POST', 'OPTIONS'], ['Content-Type', 'X-CSRF-Token'], true);
 
 start_secure_session();

--- a/api-lib.php
+++ b/api-lib.php
@@ -17,6 +17,9 @@ if (is_file($envFile)) {
     require_once $envFile;
 }
 
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'db.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'security.php';
+
 const DATA_DIR = __DIR__ . DIRECTORY_SEPARATOR . 'data';
 const DATA_FILE = DATA_DIR . DIRECTORY_SEPARATOR . 'store.json';
 const BACKUP_DIR = DATA_DIR . DIRECTORY_SEPARATOR . 'backups';
@@ -820,6 +823,7 @@ function verify_admin_password(string $password): bool
 
     $plain = getenv(ADMIN_PASSWORD_ENV);
     if (is_string($plain) && $plain !== '') {
+        error_log('Piel en Armonía SECURITY WARNING: Using plain text admin password. Please migrate to PIELARMONIA_ADMIN_PASSWORD_HASH.');
         return hash_equals($plain, $password);
     }
 

--- a/api.php
+++ b/api.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 require_once __DIR__ . '/api-lib.php';
 require_once __DIR__ . '/payment-lib.php';
 
+apply_security_headers(false);
+
 $requestStartedAt = microtime(true);
 
 set_exception_handler(static function (Throwable $e): void {

--- a/bin/generate_hash.php
+++ b/bin/generate_hash.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+if ($argc < 2) {
+    echo "Uso: php bin/generate_hash.php <password>\n";
+    exit(1);
+}
+
+$password = $argv[1];
+$hash = password_hash($password, PASSWORD_BCRYPT);
+
+echo "Contraseña: " . $password . "\n";
+echo "Hash: " . $hash . "\n";
+echo "\n";
+echo "Configuración para env.php:\n";
+echo "putenv('PIELARMONIA_ADMIN_PASSWORD_HASH=" . $hash . "');\n";

--- a/env.example.php
+++ b/env.example.php
@@ -49,3 +49,9 @@
 
 // ── Cron (recordatorios automáticos) ────────────────
 // putenv('PIELARMONIA_CRON_SECRET=un_token_secreto_largo');
+
+// ── Base de Datos (opcional) ────────────────────────
+// putenv('PIELARMONIA_DB_HOST=127.0.0.1');
+// putenv('PIELARMONIA_DB_NAME=pielarmonia');
+// putenv('PIELARMONIA_DB_USER=root');
+// putenv('PIELARMONIA_DB_PASS=secret');

--- a/figo-chat.php
+++ b/figo-chat.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/api-lib.php';
 
+apply_security_headers(false);
+
 /**
  * Figo chat endpoint.
  * Frontend -> /figo-chat.php -> configured Figo backend.

--- a/index.php
+++ b/index.php
@@ -1,12 +1,11 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/api-lib.php';
+
 if (!headers_sent()) {
     header('Content-Type: text/html; charset=UTF-8');
-    header('X-Content-Type-Options: nosniff');
-    header('X-Frame-Options: SAMEORIGIN');
-    header('Referrer-Policy: strict-origin-when-cross-origin');
-    header('Content-Security-Policy: default-src \'self\'; base-uri \'self\'; object-src \'none\'; frame-ancestors \'self\'; script-src \'self\' https://js.stripe.com https://cdnjs.cloudflare.com https://www.googletagmanager.com; style-src \'self\' https://fonts.googleapis.com https://cdnjs.cloudflare.com \'unsafe-inline\'; font-src \'self\' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src \'self\' https://images.unsplash.com https://www.google-analytics.com https://*.stripe.com data:; frame-src https://js.stripe.com https://hooks.stripe.com https://www.google.com; connect-src \'self\' https://api.stripe.com https://m.stripe.network https://r.stripe.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com; worker-src \'self\' blob:; form-action \'self\'');
+    apply_security_headers(true);
 }
 
 $indexPath = __DIR__ . DIRECTORY_SEPARATOR . 'index.html';

--- a/lib/db.php
+++ b/lib/db.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Database abstraction layer using PDO.
+ */
+
+function get_db_connection(): ?PDO
+{
+    static $pdo = null;
+    if ($pdo !== null) {
+        return $pdo;
+    }
+
+    $host = getenv('PIELARMONIA_DB_HOST');
+    $name = getenv('PIELARMONIA_DB_NAME');
+    $user = getenv('PIELARMONIA_DB_USER');
+    $pass = getenv('PIELARMONIA_DB_PASS');
+
+    if (!is_string($host) || !is_string($name) || !is_string($user) || !is_string($pass) ||
+        $host === '' || $name === '' || $user === '') {
+        return null;
+    }
+
+    try {
+        $dsn = "mysql:host={$host};dbname={$name};charset=utf8mb4";
+        $pdo = new PDO($dsn, $user, $pass, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES => false,
+        ]);
+        return $pdo;
+    } catch (PDOException $e) {
+        // Log generic error to avoid leaking credentials in DSN
+        error_log('Piel en Armonía DB Connection Error: Could not connect to database.');
+        return null;
+    }
+}
+
+/**
+ * Executes a prepared statement securely.
+ *
+ * @param string $sql SQL query with placeholders (?)
+ * @param array $params Parameters to bind
+ * @return array|int|bool Result set (array), affected rows (int for INSERT/UPDATE/DELETE), or false on failure.
+ */
+function db_query(string $sql, array $params = [])
+{
+    $pdo = get_db_connection();
+    if ($pdo === null) {
+        return false;
+    }
+
+    try {
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+
+        $trimmedSql = strtoupper(trim($sql));
+        if (strpos($trimmedSql, 'SELECT') === 0 || strpos($trimmedSql, 'SHOW') === 0 || strpos($trimmedSql, 'DESCRIBE') === 0) {
+            return $stmt->fetchAll();
+        }
+
+        return $stmt->rowCount();
+    } catch (PDOException $e) {
+        error_log('Piel en Armonía DB Query Error: ' . $e->getMessage());
+        return false;
+    }
+}

--- a/lib/security.php
+++ b/lib/security.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Security headers helper.
+ */
+
+function apply_security_headers(bool $isHtml = false): void
+{
+    if (headers_sent()) {
+        return;
+    }
+
+    // Common security headers
+    header('X-Content-Type-Options: nosniff');
+    header('X-Frame-Options: SAMEORIGIN');
+    header('Referrer-Policy: strict-origin-when-cross-origin');
+
+    // HSTS (HTTP Strict Transport Security)
+    $isHttps = false;
+    if (isset($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) === 'on' || $_SERVER['HTTPS'] === '1')) {
+        $isHttps = true;
+    } elseif (isset($_SERVER['SERVER_PORT']) && (string) $_SERVER['SERVER_PORT'] === '443') {
+        $isHttps = true;
+    } elseif (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https') {
+        $isHttps = true;
+    }
+
+    if ($isHttps) {
+        header('Strict-Transport-Security: max-age=31536000; includeSubDomains');
+    }
+
+    if ($isHtml) {
+        // CSP for HTML pages (e.g., index.php)
+        // Replicating index.php's logic but centralized to ensure consistency
+        $csp = "default-src 'self'; ";
+        $csp .= "base-uri 'self'; ";
+        $csp .= "object-src 'none'; ";
+        $csp .= "frame-ancestors 'self'; ";
+        $csp .= "script-src 'self' https://js.stripe.com https://cdnjs.cloudflare.com https://www.googletagmanager.com; ";
+        $csp .= "style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com 'unsafe-inline'; ";
+        $csp .= "font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; ";
+        $csp .= "img-src 'self' https://images.unsplash.com https://www.google-analytics.com https://*.stripe.com data:; ";
+        $csp .= "frame-src https://js.stripe.com https://hooks.stripe.com https://www.google.com; ";
+        $csp .= "connect-src 'self' https://api.stripe.com https://m.stripe.network https://r.stripe.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com; ";
+        $csp .= "worker-src 'self' blob:; ";
+        $csp .= "form-action 'self'";
+
+        header("Content-Security-Policy: $csp");
+    } else {
+        // CSP for API endpoints (JSON) - strict lockdown
+        header("Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; sandbox");
+    }
+}

--- a/proxy.php
+++ b/proxy.php
@@ -6,6 +6,9 @@ declare(strict_types=1);
  * Chatbot traffic must use /figo-chat.php
  */
 
+require_once __DIR__ . '/api-lib.php';
+apply_security_headers(false);
+
 header('Content-Type: application/json; charset=utf-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 


### PR DESCRIPTION
- Created `lib/db.php` for PDO connection and secure query execution.
- Added `lib/security.php` to enforce HTTP security headers (HSTS, CSP, etc.).
- Applied security headers to `api.php`, `index.php`, `admin-auth.php`, `figo-chat.php`, and `proxy.php`.
- Created `bin/generate_hash.php` to facilitate password migration.
- Updated `api-lib.php` to warn when using plain text admin passwords, encouraging hash migration.
- Updated `env.example.php` with DB config keys.

---
*PR created automatically by Jules for task [12245484461538010876](https://jules.google.com/task/12245484461538010876) started by @erosero558558*