### PR TITLE
Add P1 Documentation (OpenAPI, Runbooks, DR)

### DIFF
--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -1,0 +1,78 @@
+# Plan de Recuperación ante Desastres (Disaster Recovery) - Piel en Armonía
+
+Este documento define la estrategia para asegurar la continuidad del negocio y la integridad de los datos en caso de fallas graves.
+
+## 1. Objetivos
+
+*   **RPO (Recovery Point Objective):** 24 horas. (Pérdida máxima aceptable de datos).
+*   **RTO (Recovery Time Objective):** 4 horas. (Tiempo máximo para restaurar el servicio).
+
+## 2. Alcance
+
+El plan cubre:
+1.  **Código Fuente:** Repositorio Git.
+2.  **Configuración:** Variables de entorno y `env.php`.
+3.  **Datos:** Archivo `data/store.json` (Citas, Reseñas, Callbacks).
+
+## 3. Estrategia de Respaldo (Backup)
+
+### 3.1 Datos (`store.json`)
+La aplicación realiza automáticamente copias de seguridad rotativas en `data/backups/` cada vez que se escribe en el almacén de datos (citas nuevas, actualizaciones). Se guardan hasta 30 versiones anteriores.
+
+**Ubicación:** `/app/data/backups/store-YYYYMMDD-HHMMSS-XXXXXX.json`
+
+### 3.2 Código
+El código fuente reside en GitHub y se despliega mediante GitHub Actions. El repositorio es la fuente de verdad para la aplicación.
+
+### 3.3 Configuración
+Las credenciales y claves de API (Stripe, SMTP, Admin Pass) deben estar documentadas en el gestor de contraseñas del equipo y configuradas como Secrets en el repositorio.
+
+## 4. Procedimientos de Restauración
+
+### Escenario 1: Corrupción de Datos (Error lógico o borrado accidental)
+**Síntoma:** La aplicación muestra datos incorrectos o vacíos, o error de JSON.
+
+**Pasos:**
+1.  Acceder al servidor vía SFTP/SSH.
+2.  Navegar a `data/backups/`.
+3.  Identificar el archivo de backup más reciente con tamaño y fecha correctos (antes del incidente).
+4.  Detener temporalmente el tráfico (renombrar `api.php` o usar `.htaccess` deny all).
+5.  Copiar el backup seleccionado a `data/store.json`.
+    ```bash
+    cp data/backups/store-20231025-100000-a1b2c3.json data/store.json
+    ```
+6.  Verificar que el JSON sea válido.
+7.  Restaurar acceso y verificar funcionalidad (`/health`).
+
+### Escenario 2: Pérdida Total del Servidor (Hosting caído o borrado)
+**Síntoma:** El servidor no responde y no es recuperable.
+
+**Pasos:**
+1.  **Provisionar Nuevo Servidor:** Contratar nuevo hosting compatible con PHP 7.4+.
+2.  **Configurar Entorno:**
+    *   Subir archivos del proyecto (ver `DESPLIEGUE-PIELARMONIA.md`).
+    *   Configurar variables de entorno (desde gestor de contraseñas).
+    *   Asegurar permisos de escritura en `data/`.
+3.  **Restaurar Datos:**
+    *   Si se tiene copia local reciente de `store.json`, subirla a `data/`.
+    *   Si no, contactar al proveedor de hosting anterior para intentar recuperar backups de sistema.
+4.  **Redirigir DNS:** Apuntar el dominio `pielarmonia.com` a la nueva IP.
+5.  **Verificación:** Ejecutar `GATE-POSTDEPLOY.ps1`.
+
+### Escenario 3: Compromiso de Seguridad (Hackeo)
+**Síntoma:** Archivos modificados, admin password comprometida.
+
+**Pasos:**
+1.  **Aislar:** Cambiar contraseñas de hosting y base de datos (si aplica).
+2.  **Limpiar:** Borrar todo el contenido del servidor `public_html`.
+3.  **Redesplegar:** Realizar un despliegue limpio desde el repositorio Git confiable.
+4.  **Rotar Secretos:** Cambiar `PIELARMONIA_ADMIN_PASSWORD`, claves de Stripe, SMTP, etc.
+5.  **Auditar Datos:** Revisar `store.json` línea por línea para asegurar que no hay inyecciones o datos falsos.
+
+## 5. Pruebas de Recuperación
+
+Se recomienda realizar un simulacro de restauración semestralmente:
+1.  Descargar el último backup de producción.
+2.  Levantar un servidor local (`php -S localhost:8080`).
+3.  Cargar el backup en el entorno local.
+4.  Verificar que las citas y reseñas se cargan correctamente.

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1,0 +1,102 @@
+# Runbooks Operacionales - Piel en Armonía
+
+Este documento detalla los procedimientos estándar para la operación, despliegue y respuesta a incidentes del sistema Piel en Armonía.
+
+## 1. Despliegue (Deployment)
+
+Para detalles técnicos profundos, ver `DESPLIEGUE-PIELARMONIA.md`.
+
+### 1.1 Despliegue Automático (Recomendado)
+El repositorio cuenta con un flujo de GitHub Actions (`.github/workflows/deploy-hosting.yml`) que se dispara al hacer push a la rama `main`.
+
+**Pasos:**
+1.  Realizar cambios en una rama de `feature`.
+2.  Crear Pull Request y fusionar a `main`.
+3.  Verificar la ejecución del Action en la pestaña "Actions" de GitHub.
+4.  Una vez completado (verde), ejecutar la validación post-despliegue.
+
+### 1.2 Despliegue Manual (FTP)
+Si el despliegue automático falla, se puede subir manualmente.
+
+**Pasos:**
+1.  Ejecutar `npm run bundle:deploy` para generar el paquete ZIP en `_deploy_bundle/`.
+2.  Conectarse al servidor FTP (credenciales en gestor de contraseñas del equipo).
+3.  Subir el contenido del ZIP a `public_html/`.
+4.  **Importante:** No sobrescribir la carpeta `data/` si ya contiene datos de producción.
+
+### 1.3 Validación Post-Despliegue
+Después de cualquier despliegue, ejecutar el script de verificación:
+
+```powershell
+.\GATE-POSTDEPLOY.ps1 -Domain "https://pielarmonia.com"
+```
+
+Esto verificará:
+*   Estado HTTP 200 en páginas clave.
+*   Respuesta de la API (`/health`).
+*   Configuración de seguridad (Headers).
+
+---
+
+## 2. Respuesta a Incidentes (Emergency Response)
+
+### 2.1 Sitio Caído (HTTP 500 / Timeout)
+**Síntoma:** El sitio no carga o muestra error de servidor.
+
+**Acciones:**
+1.  **Verificar Logs:** Acceder por FTP y revisar `php.log` o `error_log` en la raíz.
+2.  **Health Check:** Consultar `https://pielarmonia.com/api.php?resource=health` para ver si la API responde JSON.
+3.  **Revertir:** Si fue tras un despliegue, volver a desplegar la versión anterior (revert commit en Git y push).
+4.  **Infraestructura:** Verificar estado del proveedor de hosting.
+
+### 2.2 Corrupción de Datos
+**Síntoma:** Datos faltantes, citas erróneas, JSON inválido en `store.json`.
+
+**Acciones:**
+1.  **Detener Escrituras:** Renombrar `api.php` temporalmente o poner el sitio en mantenimiento para evitar nuevas escrituras.
+2.  **Evaluar Daño:** Descargar `data/store.json` y validar su sintaxis JSON.
+3.  **Restaurar:** Seguir el procedimiento de **Disaster Recovery** (ver `docs/DISASTER_RECOVERY.md`).
+
+### 2.3 Fallo en Pagos (Stripe)
+**Síntoma:** Usuarios reportan que no pueden pagar o citas no se confirman.
+
+**Acciones:**
+1.  **Verificar Config:** `GET /payment-config` debe devolver `enabled: true`.
+2.  **Stripe Dashboard:** Verificar si hay errores en los logs de Stripe (API keys expiradas, webhooks fallidos).
+3.  **Logs de Auditoría:** Revisar `data/audit.log` buscando eventos `stripe.webhook_failed`.
+
+### 2.4 Chatbot No Responde
+**Síntoma:** El chat se queda cargando o da error.
+
+**Acciones:**
+1.  **Verificar Figo:** Consultar `https://pielarmonia.com/figo-chat.php`. Debe devolver diagnóstico.
+2.  **Reiniciar:** No aplica (PHP stateless), pero revisar si la variable de entorno `FIGO_CHAT_ENDPOINT` es correcta.
+
+---
+
+## 3. Tareas Rutinarias (Routine Tasks)
+
+### 3.1 Monitoreo Diario
+*   Visitar el sitio y verificar carga rápida.
+*   Verificar que `https://pielarmonia.com/api.php?resource=health` esté OK.
+
+### 3.2 Backup Semanal
+Aunque el sistema guarda backups rotativos en `data/backups/`, se recomienda descargar una copia local semanalmente.
+
+**Comando:**
+Conectarse por SFTP y descargar `data/store.json`.
+
+### 3.3 Revisión de Auditoría
+Revisar `data/audit.log` semanalmente en busca de:
+*   Accesos no autorizados (`api.unauthorized`).
+*   Intentos de fuerza bruta.
+*   Errores recurrentes de la API.
+
+---
+
+## 4. Monitoreo y Rendimiento
+
+Utilizar los scripts de PowerShell incluidos en el repositorio para métricas.
+
+*   **Latencia:** `.\BENCH-API-PRODUCCION.ps1` mide el tiempo de respuesta de la API.
+*   **Disponibilidad:** `.\SMOKE-PRODUCCION.ps1` realiza un recorrido rápido por las URLs principales.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,573 @@
+openapi: 3.0.0
+info:
+  title: Piel en Armonía API
+  description: |
+    API for appointment booking, reviews, and callbacks for Piel en Armonía clinic.
+
+    **Routing Note:**
+    This API uses a legacy routing mechanism via the `resource` query parameter.
+    All endpoints are accessed via `api.php`.
+    Example: The logical resource `/health` is accessed via `GET /api.php?resource=health`.
+  version: 1.0.0
+servers:
+  - url: https://pielarmonia.com
+    description: Production Server
+  - url: http://localhost:8080
+    description: Local Development Server
+
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: PHPSESSID
+    csrfToken:
+      type: apiKey
+      in: header
+      name: X-CSRF-Token
+
+  schemas:
+    Appointment:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        service:
+          type: string
+          description: Service identifier (e.g., 'consulta', 'laser')
+        doctor:
+          type: string
+          description: Doctor identifier (e.g., 'rosero', 'narvaez')
+        date:
+          type: string
+          format: date
+          example: '2023-10-25'
+        time:
+          type: string
+          example: '10:00'
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        phone:
+          type: string
+        reason:
+          type: string
+        affectedArea:
+          type: string
+        evolutionTime:
+          type: string
+        privacyConsent:
+          type: boolean
+        casePhotoUrls:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+          enum: [confirmed, pending, cancelled, completed]
+        paymentMethod:
+          type: string
+          enum: [card, transfer, cash, unpaid]
+        paymentStatus:
+          type: string
+          enum: [paid, pending, pending_cash, pending_transfer_review, failed]
+      required:
+        - service
+        - date
+        - time
+        - name
+        - email
+        - phone
+        - privacyConsent
+
+    Callback:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        telefono:
+          type: string
+        preferencia:
+          type: string
+        fecha:
+          type: string
+          format: date-time
+          readOnly: true
+        status:
+          type: string
+          enum: [pendiente, contactado]
+      required:
+        - telefono
+
+    Review:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+        rating:
+          type: integer
+          minimum: 1
+          maximum: 5
+        text:
+          type: string
+        date:
+          type: string
+          format: date-time
+          readOnly: true
+        verified:
+          type: boolean
+      required:
+        - name
+        - rating
+        - text
+
+    Availability:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: string
+          example: "09:00"
+      description: Map of date strings (YYYY-MM-DD) to arrays of available time slots.
+
+paths:
+  /api.php?resource=health:
+    get:
+      summary: API Health Check
+      description: Returns the health status of the API and storage.
+      tags: [System]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  status:
+                    type: string
+                  storageReady:
+                    type: boolean
+                  version:
+                    type: string
+
+  /api.php?resource=payment-config:
+    get:
+      summary: Get Payment Configuration
+      description: Returns public Stripe key and currency settings.
+      tags: [Payment]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  provider:
+                    type: string
+                  enabled:
+                    type: boolean
+                  publishableKey:
+                    type: string
+                  currency:
+                    type: string
+
+  /api.php?resource=availability:
+    get:
+      summary: Get Availability Slots
+      description: Returns configured availability slots.
+      tags: [Appointments]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/Availability'
+    post:
+      summary: Update Availability
+      description: Updates the availability configuration. Requires Admin authentication.
+      tags: [Appointments, Admin]
+      security:
+        - cookieAuth: []
+        - csrfToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                availability:
+                  $ref: '#/components/schemas/Availability'
+      responses:
+        '200':
+          description: Updated successfully
+
+  /api.php?resource=booked-slots:
+    get:
+      summary: Get Booked Slots
+      description: Returns a list of time slots that are already booked for a specific date and doctor.
+      tags: [Appointments]
+      parameters:
+        - in: query
+          name: date
+          schema:
+            type: string
+            format: date
+          required: true
+        - in: query
+          name: doctor
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      type: string
+
+  /api.php?resource=reviews:
+    get:
+      summary: Get Reviews
+      description: Returns a list of patient reviews.
+      tags: [Reviews]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Review'
+    post:
+      summary: Submit Review
+      description: Submit a new review.
+      tags: [Reviews]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Review'
+      responses:
+        '201':
+          description: Created
+
+  /api.php?resource=appointments:
+    get:
+      summary: Get All Appointments
+      description: Returns all appointments. Requires Admin authentication.
+      tags: [Appointments, Admin]
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Appointment'
+    post:
+      summary: Create Appointment
+      description: Book a new appointment.
+      tags: [Appointments]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Appointment'
+      responses:
+        '201':
+          description: Created
+    patch:
+      summary: Update Appointment
+      description: Update an existing appointment. Requires Admin authentication.
+      tags: [Appointments, Admin]
+      security:
+        - cookieAuth: []
+        - csrfToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: integer
+                status:
+                  type: string
+                paymentStatus:
+                  type: string
+      responses:
+        '200':
+          description: Updated
+
+  /api.php?resource=callbacks:
+    get:
+      summary: Get Callbacks
+      description: Returns all callback requests. Requires Admin authentication.
+      tags: [Callbacks, Admin]
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Callback'
+    post:
+      summary: Request Callback
+      description: Request a callback from the clinic.
+      tags: [Callbacks]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Callback'
+      responses:
+        '201':
+          description: Created
+    patch:
+      summary: Update Callback
+      description: Update callback status. Requires Admin authentication.
+      tags: [Callbacks, Admin]
+      security:
+        - cookieAuth: []
+        - csrfToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: integer
+                status:
+                  type: string
+      responses:
+        '200':
+          description: Updated
+
+  /api.php?resource=payment-intent:
+    post:
+      summary: Create Payment Intent
+      description: Create a Stripe Payment Intent for an appointment.
+      tags: [Payment]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Appointment'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  clientSecret:
+                    type: string
+                  paymentIntentId:
+                    type: string
+
+  /api.php?resource=payment-verify:
+    post:
+      summary: Verify Payment
+      description: Verify the status of a Payment Intent.
+      tags: [Payment]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                paymentIntentId:
+                  type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  paid:
+                    type: boolean
+                  status:
+                    type: string
+
+  /api.php?resource=transfer-proof:
+    post:
+      summary: Upload Transfer Proof
+      description: Upload a proof of bank transfer.
+      tags: [Payment]
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                proof:
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: Uploaded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      transferProofUrl:
+                        type: string
+
+  /api.php?resource=stripe-webhook:
+    post:
+      summary: Stripe Webhook
+      description: Endpoint for Stripe webhook events.
+      tags: [Payment]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Received
+
+  /api.php?resource=reschedule:
+    get:
+      summary: Get Reschedule Info
+      description: Get appointment details by reschedule token.
+      tags: [Appointments]
+      parameters:
+        - in: query
+          name: token
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Success
+    patch:
+      summary: Reschedule Appointment
+      description: Reschedule an appointment using a token.
+      tags: [Appointments]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                date:
+                  type: string
+                  format: date
+                time:
+                  type: string
+      responses:
+        '200':
+          description: Success
+
+  /api.php?resource=data:
+    get:
+      summary: Get All Data
+      description: Dump of the entire data store. Requires Admin authentication.
+      tags: [System, Admin]
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: Success
+
+  /api.php?resource=import:
+    post:
+      summary: Import Data
+      description: Import data into the store. Requires Admin authentication.
+      tags: [System, Admin]
+      security:
+        - cookieAuth: []
+        - csrfToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                appointments:
+                  type: array
+                callbacks:
+                  type: array
+                reviews:
+                  type: array
+                availability:
+                  $ref: '#/components/schemas/Availability'
+      responses:
+        '200':
+          description: Success


### PR DESCRIPTION
Added `docs/` directory with `openapi.yaml`, `RUNBOOKS.md`, and `DISASTER_RECOVERY.md` to address P1 documentation tasks.

---
*PR created automatically by Jules for task [5559376155843123846](https://jules.google.com/task/5559376155843123846) started by @erosero558558*