### PR TITLE
fix: resolve redeclaration error in validation.php and verify backup system

### DIFF
--- a/lib/validation.php
+++ b/lib/validation.php
@@ -7,11 +7,6 @@ require_once __DIR__ . '/common.php';
  * Validation and sanitization helpers.
  */
 
-function local_date(string $format): string
-{
-    return date($format);
-}
-
 function sanitize_phone(string $phone): string
 {
     return trim($phone);

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => '__root__',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '29f36b014c193b0a53d807f607edd77c8b76552b',
+        'reference' => 'b0d44febeb5cf02e1d1d238b2b5f053bb02ebc7a',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         '__root__' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '29f36b014c193b0a53d807f607edd77c8b76552b',
+            'reference' => 'b0d44febeb5cf02e1d1d238b2b5f053bb02ebc7a',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
# Backup Verification Report

Per the user request, I have verified the backup system status:

1.  **¿Backups diarios de BD funcionan?**
    *   **Yes.** The system uses a transactional backup mechanism. Every time `write_store` is called, a backup of the current state is saved to `data/backups/` before overwriting `store.json`.
    *   Verified via a test script (`tests/test-backup-mechanism.php`, now deleted) which successfully triggered backup creation.

2.  **¿Se prueban mensualmente?**
    *   **No automated tests exist** for this specific purpose.
    *   `docs/DISASTER_RECOVERY.md` recommends a **semi-annual** manual simulation.

3.  **¿Hay off-site backup?**
    *   **No.** Code analysis of `lib/storage.php` and search for keywords (S3, FTP, AWS, etc.) confirms backups are stored locally in `data/backups/`.
    *   `docs/DISASTER_RECOVERY.md` suggests using the hosting provider's backup or manual download as a fallback.

4.  **¿Cuál es el tiempo de recuperación (RTO)?**
    *   **4 hours**, as defined in `docs/DISASTER_RECOVERY.md`.

# Fix Details
*   **lib/validation.php**: Removed `local_date` function which was already defined in `lib/common.php`. This redundancy caused fatal errors when running scripts that required both libraries (like the backup verification script).


---
*PR created automatically by Jules for task [10521698076347411881](https://jules.google.com/task/10521698076347411881) started by @erosero558558*