### PR TITLE
Add backup verification scripts and regression test

### DIFF
--- a/tests/test_storage_backup.php
+++ b/tests/test_storage_backup.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+// Set up temporary environment for testing
+$tmpDataDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pielarmonia-test-storage-' . uniqid();
+putenv("PIELARMONIA_DATA_DIR=$tmpDataDir");
+
+// Clean up any existing directory (unlikely with uniqid but good practice)
+if (is_dir($tmpDataDir)) {
+    exec("rm -rf " . escapeshellarg($tmpDataDir));
+}
+mkdir($tmpDataDir, 0777, true);
+
+// Include dependencies
+require_once __DIR__ . '/test_framework.php';
+require_once __DIR__ . '/../lib/storage.php';
+
+echo "Testing Storage Backup Logic...\n";
+echo "Using temp data dir: $tmpDataDir\n";
+
+run_test('Writing to store should create a backup of the previous state', function() use ($tmpDataDir) {
+    // 1. Create initial state
+    // read_store() creates seed file if missing.
+    $initialStore = read_store();
+    $initialStore['test_key'] = 'initial_value';
+
+    // First write. This creates a backup of the SEED data (empty structure).
+    write_store($initialStore);
+
+    // Verify file exists
+    $storeFile = $tmpDataDir . '/store.json';
+    assert_true(file_exists($storeFile), 'store.json should exist');
+    $contentAfterFirstWrite = file_get_contents($storeFile);
+    $decodedFirst = json_decode($contentAfterFirstWrite, true);
+    assert_equals('initial_value', $decodedFirst['test_key'] ?? null, 'Store should have initial value');
+
+    // 2. Modify state (this triggers backup of step 1)
+    $modifiedStore = $initialStore;
+    $modifiedStore['test_key'] = 'modified_value';
+
+    // Wait at least 1 second to ensure timestamp change for deterministic sorting
+    sleep(1);
+
+    write_store($modifiedStore);
+
+    // 3. Check for backup file
+    $backupDir = $tmpDataDir . '/backups';
+    assert_true(is_dir($backupDir), 'Backup directory should exist');
+
+    $files = glob($backupDir . '/store-*.json');
+    assert_greater_than(0, count($files), 'There should be at least one backup file');
+
+    // Sort to get the latest (which should be the one created just now)
+    sort($files);
+    $latestBackup = end($files);
+
+    // 4. Verify content of backup
+    // The backup should contain the state BEFORE the second write, i.e., 'initial_value'
+    $backupContent = file_get_contents($latestBackup);
+    $backupData = json_decode($backupContent, true);
+
+    assert_true(is_array($backupData), 'Backup content should be valid JSON');
+    assert_equals('initial_value', $backupData['test_key'] ?? null, 'Backup should contain the previous state value');
+
+    // Verify current store has new value
+    $currentStore = read_store();
+    assert_equals('modified_value', $currentStore['test_key'] ?? null, 'Current store should have the new value');
+});
+
+run_test('Backup rotation (max backups)', function() use ($tmpDataDir) {
+    // Clear backups from previous test
+    $backupDir = $tmpDataDir . '/backups';
+    $files = glob($backupDir . '/*');
+    foreach($files as $f) unlink($f);
+
+    if (!is_dir($backupDir)) mkdir($backupDir, 0777, true);
+
+    // Create 35 dummy files
+    for ($i = 0; $i < 35; $i++) {
+        // Ensure filenames sort correctly
+        $name = sprintf('store-20230101-%06d-dummy.json', $i);
+        file_put_contents($backupDir . '/' . $name, json_encode(['id' => $i]));
+    }
+
+    // Now trigger one write_store which will create one more real backup and then prune
+    $store = read_store();
+    $store['rotation_test'] = true;
+    write_store($store);
+
+    // Now count files
+    $files = glob($backupDir . '/store-*.json');
+
+    // Should be exactly 30 (MAX_STORE_BACKUPS)
+    assert_equals(30, count($files), 'Should have exactly 30 backup files after rotation');
+});
+
+// Cleanup
+exec("rm -rf " . escapeshellarg($tmpDataDir));
+
+print_test_summary();

--- a/verification/verify_backup_status.php
+++ b/verification/verify_backup_status.php
@@ -1,0 +1,129 @@
+<?php
+declare(strict_types=1);
+
+// This script verifies the current status of backups in the environment.
+// It is intended to answer the checklist questions.
+
+require_once __DIR__ . '/../lib/storage.php';
+
+echo "=== Backup Status Verification ===\n";
+echo "Date: " . date('Y-m-d H:i:s') . "\n\n";
+
+// 1. Check Data Directory
+$dataDir = data_dir_path();
+echo "Data Directory: $dataDir\n";
+if (!is_dir($dataDir)) {
+    echo "❌ Data directory not found!\n";
+} else {
+    echo "✅ Data directory exists.\n";
+}
+
+// 2. Check Store File
+$storeFile = data_file_path();
+if (file_exists($storeFile)) {
+    echo "✅ store.json exists (" . filesize($storeFile) . " bytes)\n";
+} else {
+    echo "⚠️ store.json does not exist (New installation?)\n";
+}
+
+// 3. Check Backups
+$backupDir = backup_dir_path();
+$backupCount = 0;
+echo "\n--- Automated DB Backups (Daily/Rotational) ---\n";
+if (is_dir($backupDir)) {
+    $files = glob($backupDir . '/store-*.json');
+    $backupCount = is_array($files) ? count($files) : 0;
+    echo "Backup Directory: $backupDir\n";
+    echo "Total Backups Found: $backupCount\n";
+
+    if ($backupCount > 0) {
+        sort($files);
+        $latest = end($files);
+        $oldest = reset($files);
+        echo "✅ Backups exist.\n";
+        echo "   Oldest: " . basename($oldest) . " (" . date('Y-m-d H:i:s', filemtime($oldest)) . ")\n";
+        echo "   Latest: " . basename($latest) . " (" . date('Y-m-d H:i:s', filemtime($latest)) . ")\n";
+
+        // Parse latest backup to verify integrity
+        $content = file_get_contents($latest);
+        if (json_decode($content)) {
+             echo "✅ Latest backup is valid JSON.\n";
+        } else {
+             echo "❌ Latest backup is INVALID JSON.\n";
+        }
+    } else {
+        echo "⚠️ No backups found yet (System unused?)\n";
+    }
+} else {
+    echo "❌ Backup directory does not exist.\n";
+}
+
+// 4. File Backups (Uploads/Configs)
+echo "\n--- File Backups (Uploads/Configs) ---\n";
+$uploadsDir = __DIR__ . '/../uploads';
+if (is_dir($uploadsDir)) {
+    echo "Uploads Directory: $uploadsDir\n";
+    echo "⚠️ No specific backup mechanism detected for uploads/ in codebase.\n";
+    echo "   (Recommendation: Use rsync/S3 for uploads backup)\n";
+} else {
+    echo "ℹ️ Uploads directory not found.\n";
+}
+
+// Configs check
+$envFile = __DIR__ . '/../env.php';
+if (file_exists($envFile)) {
+    echo "Config: env.php exists (Not backed up by app logic, relies on manual/infra backup).\n";
+} else {
+    echo "Config: env.php not found (Environment variables used?)\n";
+}
+
+
+// 5. Off-site Backups
+echo "\n--- Off-site Backups ---\n";
+// Check for scripts
+$binDir = __DIR__ . '/../bin';
+$hasOffsiteScript = false;
+if (is_dir($binDir)) {
+    foreach (glob($binDir . '/*') as $script) {
+        if (!is_file($script)) continue;
+        $content = file_get_contents($script);
+        if (stripos($content, 's3') !== false || stripos($content, 'ftp') !== false || stripos($content, 'scp') !== false) {
+            echo "❓ Found potential backup script: " . basename($script) . "\n";
+            $hasOffsiteScript = true;
+        }
+    }
+}
+if (!$hasOffsiteScript) {
+    echo "❌ No automated off-site backup script found in bin/.\n";
+}
+
+// 6. RTO/RPO
+echo "\n--- RTO/RPO ---\n";
+$drFile = __DIR__ . '/../docs/DISASTER_RECOVERY.md';
+$rpo = "Unknown";
+$rto = "Unknown";
+
+if (file_exists($drFile)) {
+    $drContent = file_get_contents($drFile);
+    if (preg_match('/RPO.*?:\**\s*(.*?)$/m', $drContent, $matches)) {
+        $rpo = trim($matches[1]);
+        echo "Defined RPO: " . $rpo . "\n";
+    } else {
+        echo "RPO not found in docs.\n";
+    }
+    if (preg_match('/RTO.*?:\**\s*(.*?)$/m', $drContent, $matches)) {
+        $rto = trim($matches[1]);
+        echo "Defined RTO: " . $rto . "\n";
+    } else {
+        echo "RTO not found in docs.\n";
+    }
+} else {
+    echo "⚠️ DISASTER_RECOVERY.md not found.\n";
+}
+
+echo "\n=== Summary for User Checklist ===\n";
+echo "1. ¿Existen backups automáticos de BD? (daily) -> " . ($backupCount > 0 ? "YES (On-change rotation)" : "NO (Files missing, but logic enabled)") . "\n";
+echo "2. ¿Se prueban los backups regularmente? -> NO (No automated restore test found)\n";
+echo "3. ¿Hay backup de archivos (uploads, configs)? -> NO (Code only covers store.json)\n";
+echo "4. ¿Los backups están off-site? -> NO (Stored locally in data/backups)\n";
+echo "5. ¿Cuál es el RTO/RPO definido? -> RPO: $rpo, RTO: $rto\n";


### PR DESCRIPTION
This PR introduces tools to verify the status of automated backups for Piel en Armonía.

Changes:
1.  **Verification Script (`verification/verify_backup_status.php`)**: A read-only script that inspects the environment to report on:
    *   Existence and integrity of `data/store.json` backups.
    *   Status of `uploads/` and `env.php` backups (checks for mechanisms).
    *   Presence of off-site backup scripts.
    *   RTO/RPO definitions extracted from `DISASTER_RECOVERY.md`.
    *   Generates a summary matching the user's checklist.

2.  **Regression Test (`tests/test_storage_backup.php`)**: A PHP test that:
    *   Simulates a storage environment using a temporary directory.
    *   Verifies that `write_store()` creates a backup of the previous state.
    *   Verifies that the rotation logic respects `MAX_STORE_BACKUPS` (30).

Verification Results (Sandbox):
-   Automated DB Backups: Logic validated, but no files in fresh sandbox.
-   Regular Testing: No existing pipeline found (new test fills this gap).
-   File Backups: No mechanism found for `uploads/`.
-   Off-site: No mechanism found.
-   RTO/RPO: 24h / 4h.

---
*PR created automatically by Jules for task [12187152519764719156](https://jules.google.com/task/12187152519764719156) started by @erosero558558*