### PR TITLE
Add unit tests for Booking, RateLimiter, and AuthSession

### DIFF
--- a/tests/Unit/Auth/AuthSessionTest.php
+++ b/tests/Unit/Auth/AuthSessionTest.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Auth;
+
+use PHPUnit\Framework\TestCase;
+
+// Include necessary files
+require_once __DIR__ . '/../../../lib/auth.php';
+
+class AuthSessionTest extends TestCase
+{
+    private string|false $originalPassword;
+    private string|false $originalSecret;
+
+    protected function setUp(): void
+    {
+        // Save original environment
+        $this->originalPassword = getenv('PIELARMONIA_ADMIN_PASSWORD');
+        $this->originalSecret = getenv('PIELARMONIA_ADMIN_2FA_SECRET');
+
+        // Set test environment
+        putenv('PIELARMONIA_ADMIN_PASSWORD=test_password');
+        putenv('PIELARMONIA_ADMIN_2FA_SECRET=JBSWY3DPEHPK3PXP'); // Base32 secret
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore environment
+        if ($this->originalPassword !== false) {
+            putenv("PIELARMONIA_ADMIN_PASSWORD={$this->originalPassword}");
+        } else {
+            putenv('PIELARMONIA_ADMIN_PASSWORD');
+        }
+
+        if ($this->originalSecret !== false) {
+            putenv("PIELARMONIA_ADMIN_2FA_SECRET={$this->originalSecret}");
+        } else {
+            putenv('PIELARMONIA_ADMIN_2FA_SECRET');
+        }
+    }
+
+    public function testVerifyAdminPassword(): void
+    {
+        $this->assertTrue(verify_admin_password('test_password'));
+        $this->assertFalse(verify_admin_password('wrong_password'));
+    }
+
+    public function testVerify2FACode(): void
+    {
+        $secret = 'JBSWY3DPEHPK3PXP';
+        $code = $this->generateValidTOTP($secret);
+
+        $this->assertTrue(verify_2fa_code($code), "Valid code $code should be accepted");
+
+        $invalidCode = '123456';
+        if ($invalidCode === $code) {
+            $invalidCode = '654321';
+        }
+        $this->assertFalse(verify_2fa_code($invalidCode), "Invalid code should be rejected");
+    }
+
+    /**
+     * Helper to generate a valid TOTP code for testing.
+     * Logic adapted from lib/totp.php private method getCode.
+     */
+    private function generateValidTOTP(string $secret): string
+    {
+        $timestamp = time();
+        $period = 30;
+        $digits = 6;
+
+        $timeSlice = (int) floor($timestamp / $period);
+        $timePacked = pack('N*', 0) . pack('N*', $timeSlice);
+
+        $key = $this->base32Decode($secret);
+        $hmac = hash_hmac('sha1', $timePacked, $key, true);
+        $offset = ord($hmac[19]) & 0xf;
+        $token = (
+            ((ord($hmac[$offset+0]) & 0x7f) << 24) |
+            ((ord($hmac[$offset+1]) & 0xff) << 16) |
+            ((ord($hmac[$offset+2]) & 0xff) << 8) |
+            (ord($hmac[$offset+3]) & 0xff)
+        ) % 1000000;
+
+        return str_pad((string)$token, $digits, '0', STR_PAD_LEFT);
+    }
+
+    private function base32Decode(string $base32): string
+    {
+        $base32 = strtoupper($base32);
+        $l = strlen($base32);
+        $n = 0;
+        $j = 0;
+        $binary = '';
+        $map = array_flip(str_split('ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'));
+
+        for ($i = 0; $i < $l; $i++) {
+            if (!isset($map[$base32[$i]])) continue;
+            $n = $n << 5;
+            $n = $n + $map[$base32[$i]];
+            $j = $j + 5;
+            if ($j >= 8) {
+                $j = $j - 8;
+                $binary .= chr(($n & (0xFF << $j)) >> $j);
+            }
+        }
+        return $binary;
+    }
+}

--- a/tests/Unit/Booking/BookingServiceTest.php
+++ b/tests/Unit/Booking/BookingServiceTest.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Booking;
+
+use PHPUnit\Framework\TestCase;
+
+// Include the business logic file
+// It requires 'common.php' and 'validation.php' so we assume they are present
+require_once __DIR__ . '/../../../lib/business.php';
+
+class BookingServiceTest extends TestCase
+{
+    public function testGetServicesConfigReturnsArray(): void
+    {
+        $config = get_services_config();
+        $this->assertIsArray($config);
+        $this->assertArrayHasKey('consulta', $config);
+        $this->assertArrayHasKey('laser', $config);
+    }
+
+    public function testGetServicePriceBreakdownStructure(): void
+    {
+        $breakdown = get_service_price_breakdown('consulta');
+
+        $this->assertIsArray($breakdown);
+        $this->assertArrayHasKey('service_id', $breakdown);
+        $this->assertArrayHasKey('pricing', $breakdown);
+        $this->assertArrayHasKey('formatted', $breakdown);
+
+        $this->assertEquals('consulta', $breakdown['service_id']);
+        $this->assertEquals(40.0, $breakdown['pricing']['base_amount']);
+    }
+
+    public function testComputeTaxCalculation(): void
+    {
+        // Test with 15% tax
+        $base = 100.0;
+        $taxRate = 0.15;
+        $tax = compute_tax($base, $taxRate);
+        $total = compute_total($base, $taxRate);
+
+        $this->assertEquals(15.0, $tax);
+        $this->assertEquals(115.0, $total);
+    }
+
+    public function testValidatePaymentAmount(): void
+    {
+        // Consulta base is 40.00, tax 0% -> total 40.00
+        $service = 'consulta';
+        $amount = 40.00;
+
+        $result = validate_payment_amount($service, $amount);
+        $this->assertTrue($result['valid']);
+
+        // Test invalid amount
+        $invalidAmount = 30.00;
+        $resultInvalid = validate_payment_amount($service, $invalidAmount);
+        $this->assertFalse($resultInvalid['valid']);
+        $this->assertArrayHasKey('error', $resultInvalid);
+    }
+
+    public function testAppointmentSlotTakenLogic(): void
+    {
+        $appointments = [
+            [
+                'date' => '2024-01-01',
+                'time' => '10:00',
+                'status' => 'confirmed',
+                'doctor' => 'rosero',
+                'id' => 1
+            ],
+            [
+                'date' => '2024-01-01',
+                'time' => '11:00',
+                'status' => 'cancelled', // Cancelled should be free
+                'doctor' => 'rosero',
+                'id' => 2
+            ]
+        ];
+
+        // Slot taken
+        $this->assertTrue(
+            appointment_slot_taken($appointments, '2024-01-01', '10:00'),
+            'Slot 10:00 should be taken'
+        );
+
+        // Slot free (cancelled)
+        $this->assertFalse(
+            appointment_slot_taken($appointments, '2024-01-01', '11:00'),
+            'Slot 11:00 should be free because it is cancelled'
+        );
+
+        // Slot free (different time)
+        $this->assertFalse(
+            appointment_slot_taken($appointments, '2024-01-01', '12:00'),
+            'Slot 12:00 should be free'
+        );
+
+        // Slot free (checking against self excluded)
+        $this->assertFalse(
+            appointment_slot_taken($appointments, '2024-01-01', '10:00', 1),
+            'Slot 10:00 should be free if checking against self (id 1)'
+        );
+    }
+
+    public function testGetVatRateUsesEnvironmentVariable(): void
+    {
+        // Save current env
+        $original = getenv('PIELARMONIA_VAT_RATE');
+
+        // Set new env
+        putenv('PIELARMONIA_VAT_RATE=20'); // 20%
+
+        $rate = get_vat_rate();
+        $this->assertEquals(0.20, $rate);
+
+        // Set as decimal
+        putenv('PIELARMONIA_VAT_RATE=0.10');
+        $rate = get_vat_rate();
+        $this->assertEquals(0.10, $rate);
+
+        // Restore
+        if ($original !== false) {
+            putenv("PIELARMONIA_VAT_RATE=$original");
+        } else {
+            putenv('PIELARMONIA_VAT_RATE');
+        }
+    }
+}

--- a/tests/Unit/Security/RateLimiterTest.php
+++ b/tests/Unit/Security/RateLimiterTest.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Security;
+
+use PHPUnit\Framework\TestCase;
+
+// Include necessary files
+require_once __DIR__ . '/../../../lib/storage.php';
+require_once __DIR__ . '/../../../lib/ratelimit.php';
+
+class RateLimiterTest extends TestCase
+{
+    private string $tempDir;
+    private string|false $originalEnv;
+
+    protected function setUp(): void
+    {
+        // Create a unique temporary directory for this test run
+        $this->tempDir = sys_get_temp_dir() . '/test_ratelimit_' . uniqid();
+        if (!mkdir($this->tempDir, 0777, true)) {
+            $this->markTestSkipped('Could not create temp directory');
+        }
+
+        // Save original environment variable
+        $this->originalEnv = getenv('PIELARMONIA_DATA_DIR');
+
+        // Set environment variable to point to temp dir
+        putenv("PIELARMONIA_DATA_DIR={$this->tempDir}");
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore environment variable
+        if ($this->originalEnv !== false) {
+            putenv("PIELARMONIA_DATA_DIR={$this->originalEnv}");
+        } else {
+            putenv('PIELARMONIA_DATA_DIR');
+        }
+
+        // Clean up temp directory
+        $this->removeDirectory($this->tempDir);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = "$dir/$file";
+            (is_dir($path)) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    public function testRateLimitKeyGeneration(): void
+    {
+        $action = 'login_attempt';
+        $ip = '127.0.0.1';
+        $key = rate_limit_key($action, $ip);
+
+        $this->assertIsString($key);
+        $this->assertEquals(32, strlen($key)); // MD5 hash length
+
+        // Same inputs should produce same key
+        $key2 = rate_limit_key($action, $ip);
+        $this->assertEquals($key, $key2);
+
+        // Different IP should produce different key
+        $key3 = rate_limit_key($action, '192.168.1.1');
+        $this->assertNotEquals($key, $key3);
+    }
+
+    public function testCheckRateLimitEnforcement(): void
+    {
+        $action = 'test_action_' . uniqid();
+        $limit = 5;
+        $window = 60;
+
+        // Perform allowed requests
+        for ($i = 0; $i < $limit; $i++) {
+            $allowed = check_rate_limit($action, $limit, $window);
+            $this->assertTrue($allowed, "Request $i should be allowed");
+        }
+
+        // Perform blocked request
+        $blocked = check_rate_limit($action, $limit, $window);
+        $this->assertFalse($blocked, "Request exceeding limit should be blocked");
+    }
+
+    public function testRateLimitReset(): void
+    {
+        $action = 'reset_test_' . uniqid();
+        $limit = 1;
+        $window = 60;
+
+        // First request allowed
+        $this->assertTrue(check_rate_limit($action, $limit, $window));
+
+        // Second request blocked
+        $this->assertFalse(check_rate_limit($action, $limit, $window));
+
+        // Reset limit
+        reset_rate_limit($action);
+
+        // Should be allowed again
+        $this->assertTrue(check_rate_limit($action, $limit, $window));
+    }
+
+    public function testIsRateLimitedCheckOnly(): void
+    {
+        $action = 'check_only_' . uniqid();
+        $limit = 2;
+        $window = 60;
+
+        // Use check_rate_limit to increment count
+        check_rate_limit($action, $limit, $window);
+        check_rate_limit($action, $limit, $window); // Now at 2/2
+
+        // check_rate_limit would return false next time and increment.
+        // is_rate_limited should return true (blocked) without incrementing?
+        // Let's verify behavior. is_rate_limited checks if count >= maxRequests.
+
+        $this->assertTrue(is_rate_limited($action, $limit, $window));
+
+        // It shouldn't increment, so let's verify count stays same if we could inspect file,
+        // but functionally: calling is_rate_limited repeatedly should consistently return true.
+        $this->assertTrue(is_rate_limited($action, $limit, $window));
+    }
+}


### PR DESCRIPTION
Created unit tests in tests/Unit/ for BookingService, RateLimiter, and AuthSession.
- BookingServiceTest covers business logic.
- RateLimiterTest covers rate limiting logic with temp dir isolation.
- AuthSessionTest covers authentication logic including TOTP generation.

---
*PR created automatically by Jules for task [3633828986857065212](https://jules.google.com/task/3633828986857065212) started by @erosero558558*