### PR TITLE
Upgrade Consent Engine to GDPR Basic (Consent Mode v2 & Revocation)

### DIFF
--- a/content/en.json
+++ b/content/en.json
@@ -233,5 +233,6 @@
     "cookie_more": "More information",
     "footer_privacy_note": "If you share photos by web or WhatsApp, they are used only for clinical guidance and appointment management.",
     "footer_tagline": "Specialized dermatology in Quito",
-    "footer_rights": "All rights reserved."
+    "footer_rights": "All rights reserved.",
+    "legal_cookies_prefs": "Cookie Preferences"
 }

--- a/content/es.json
+++ b/content/es.json
@@ -221,5 +221,6 @@
     "cookie_banner_text": "Usamos cookies esenciales para seguridad y funcionamiento. Puedes aceptar o rechazar cookies opcionales.",
     "cookie_reject": "Rechazar",
     "cookie_accept": "Aceptar",
-    "cookie_more": "Más información"
+    "cookie_more": "Más información",
+    "legal_cookies_prefs": "Preferencias de Cookies"
 }

--- a/index.html
+++ b/index.html
@@ -2237,6 +2237,7 @@
                     <a href="terminos.html" data-i18n="legal_terms">T&eacute;rminos y Condiciones</a>
                     <a href="privacidad.html" data-i18n="legal_privacy">Pol&iacute;tica de Privacidad</a>
                     <a href="cookies.html" data-i18n="legal_cookies">Pol&iacute;tica de Cookies</a>
+                    <a href="#" id="cookiePrefsBtn" data-i18n="legal_cookies_prefs">Preferencias de Cookies</a>
                     <a href="aviso-medico.html" data-i18n="legal_disclaimer">Aviso de Responsabilidad M&eacute;dica</a>
                 </div>
 

--- a/js/engines/ui-bundle.js
+++ b/js/engines/ui-bundle.js
@@ -580,7 +580,12 @@ END:VCALENDAR`;
         function gtag() { window.dataLayer.push(arguments); }
         window.gtag = gtag;
         gtag('js', new Date());
-        gtag('consent', 'update', { analytics_storage: 'granted' });
+        gtag('consent', 'update', {
+            analytics_storage: 'granted',
+            ad_storage: 'granted',
+            ad_user_data: 'granted',
+            ad_personalization: 'granted'
+        });
         gtag('config', measurementId);
     }
 
@@ -591,6 +596,11 @@ END:VCALENDAR`;
 
         const active = isActive === true;
         banner.classList.toggle('active', active);
+    }
+
+    function showBanner() {
+        const banner = document.getElementById('cookieBanner');
+        setBannerActiveState(banner, true);
     }
 
     function handleConsentAction(action) {
@@ -611,6 +621,16 @@ END:VCALENDAR`;
         } else if (action === 'rejected') {
             setCookieConsent('rejected');
             setBannerActiveState(banner, false);
+
+            if (window.gtag) {
+                window.gtag('consent', 'update', {
+                    analytics_storage: 'denied',
+                    ad_storage: 'denied',
+                    ad_user_data: 'denied',
+                    ad_personalization: 'denied'
+                });
+            }
+
             showToastSafe(
                 getCurrentLang() === 'es'
                     ? 'Solo se mantendran cookies esenciales.'
@@ -630,6 +650,9 @@ END:VCALENDAR`;
                 handleConsentAction('accepted');
             } else if (target.closest('#cookieRejectBtn')) {
                 handleConsentAction('rejected');
+            } else if (target.closest('#cookiePrefsBtn') || target.closest('#cookieResetBtn')) {
+                e.preventDefault();
+                showBanner();
             }
         });
     }
@@ -660,7 +683,8 @@ END:VCALENDAR`;
         getCookieConsent,
         setCookieConsent,
         initGA4,
-        initCookieBanner
+        initCookieBanner,
+        showBanner
     };
 
     // Legacy support just in case

--- a/src/apps/consent/engine.js
+++ b/src/apps/consent/engine.js
@@ -74,7 +74,12 @@ function initGA4() {
     function gtag() { window.dataLayer.push(arguments); }
     window.gtag = gtag;
     gtag('js', new Date());
-    gtag('consent', 'update', { analytics_storage: 'granted' });
+    gtag('consent', 'update', {
+        analytics_storage: 'granted',
+        ad_storage: 'granted',
+        ad_user_data: 'granted',
+        ad_personalization: 'granted'
+    });
     gtag('config', measurementId);
 }
 
@@ -85,6 +90,11 @@ function setBannerActiveState(banner, isActive) {
 
     const active = isActive === true;
     banner.classList.toggle('active', active);
+}
+
+function showBanner() {
+    const banner = document.getElementById('cookieBanner');
+    setBannerActiveState(banner, true);
 }
 
 function handleConsentAction(action) {
@@ -105,6 +115,16 @@ function handleConsentAction(action) {
     } else if (action === 'rejected') {
         setCookieConsent('rejected');
         setBannerActiveState(banner, false);
+
+        if (window.gtag) {
+            window.gtag('consent', 'update', {
+                analytics_storage: 'denied',
+                ad_storage: 'denied',
+                ad_user_data: 'denied',
+                ad_personalization: 'denied'
+            });
+        }
+
         showToastSafe(
             getCurrentLang() === 'es'
                 ? 'Solo se mantendran cookies esenciales.'
@@ -124,6 +144,9 @@ function bindDelegatedListeners() {
             handleConsentAction('accepted');
         } else if (target.closest('#cookieRejectBtn')) {
             handleConsentAction('rejected');
+        } else if (target.closest('#cookiePrefsBtn') || target.closest('#cookieResetBtn')) {
+            e.preventDefault();
+            showBanner();
         }
     });
 }
@@ -154,7 +177,8 @@ window.Piel.ConsentEngine = {
     getCookieConsent,
     setCookieConsent,
     initGA4,
-    initCookieBanner
+    initCookieBanner,
+    showBanner
 };
 
 // Legacy support just in case

--- a/tests/cookie-consent.spec.js
+++ b/tests/cookie-consent.spec.js
@@ -91,4 +91,57 @@ test.describe('Consentimiento de cookies', () => {
         const ga4Loaded = await page.evaluate(() => !!window._ga4Loaded);
         expect(ga4Loaded).toBe(true);
     });
+
+    test('Boton de preferencias reabre el banner', async ({ page }) => {
+        // Aceptar primero
+        const banner = page.locator('#cookieBanner');
+        await expect(banner).toBeVisible({ timeout: 10000 });
+        await page.locator('#cookieAcceptBtn').click({ force: true });
+        await expect(banner).not.toBeVisible();
+
+        // Clic en preferencias
+        const prefsBtn = page.locator('#cookiePrefsBtn');
+        await expect(prefsBtn).toBeVisible();
+        await prefsBtn.click();
+
+        await expect(banner).toBeVisible();
+    });
+
+    test('Revocar consentimiento actualiza estado a denied', async ({ page }) => {
+        const banner = page.locator('#cookieBanner');
+        await expect(banner).toBeVisible({ timeout: 10000 });
+
+        // Aceptar
+        await page.locator('#cookieAcceptBtn').click({ force: true });
+        await expect(banner).not.toBeVisible();
+
+        // Verificar signals de aceptacion en dataLayer
+        const grantCalls = await page.evaluate(() => {
+            return window.dataLayer.filter(args =>
+                args[0] === 'consent' && args[1] === 'update' && args[2].analytics_storage === 'granted'
+            );
+        });
+        expect(grantCalls.length).toBeGreaterThan(0);
+
+        // Reabrir y Rechazar
+        await page.locator('#cookiePrefsBtn').click();
+        await expect(banner).toBeVisible();
+        await page.locator('#cookieRejectBtn').click({ force: true });
+        await expect(banner).not.toBeVisible();
+
+        // Verificar signals de rechazo (denied)
+        const denyCalls = await page.evaluate(() => {
+            return window.dataLayer.filter(args =>
+                args[0] === 'consent' && args[1] === 'update' && args[2].analytics_storage === 'denied'
+            );
+        });
+        expect(denyCalls.length).toBeGreaterThan(0);
+
+        // Verificar persistencia
+        const consent = await page.evaluate(() => {
+            const raw = localStorage.getItem('pa_cookie_consent_v1');
+            return raw ? JSON.parse(raw) : null;
+        });
+        expect(consent.status).toBe('rejected');
+    });
 });


### PR DESCRIPTION
Upgraded the Cookie Consent Engine to meet GDPR Basic compliance requirements.
- **Consent Mode v2:** Now sends granular `ad_storage`, `ad_user_data`, `ad_personalization`, and `analytics_storage` signals to Google Analytics/Tags upon acceptance.
- **Revocation:** Added a mechanism to revoke/change consent. A new "Preferencias de Cookies" link in the footer re-opens the banner.
- **Denied Signals:** Explicitly sends 'denied' updates for all signals if the user revokes consent (rejects after accepting).
- **Localization:** Added translation keys for the new preferences button.
- **Testing:** Added E2E tests to verify banner reopening and signal correctness.

---
*PR created automatically by Jules for task [6065123232172846015](https://jules.google.com/task/6065123232172846015) started by @erosero558558*