### PR TITLE
ops: add weekly retention recurrence guardrails

### DIFF
--- a/PLAN_MAESTRO_OPERATIVO_2026.md
+++ b/PLAN_MAESTRO_OPERATIVO_2026.md
@@ -144,8 +144,10 @@ Criterio de salida:
 Evidencia parcial (retencion consolidada):
 
 - `REPORTE-SEMANAL-PRODUCCION.ps1` publica `retention` + `retentionTrend` en JSON/Markdown semanal (incluye `noShowRatePct`, `recurrenceRatePct`, deltas vs reporte previo).
+- `REPORTE-SEMANAL-PRODUCCION.ps1` incorpora guardrails de retencion configurables (warning por `no_show` alto, `recurrence` baja y caida semanal de recurrencia con sample minimo).
 - `npm run report:weekly:prod` (2026-02-25) -> `Warnings: none`, con salida `retention_no_show_rate_pct=0` y `retention_recurrence_rate_pct=50`.
 - `.github/workflows/weekly-kpi-report.yml` resume metricas de retencion y deltas en `GITHUB_STEP_SUMMARY` para operacion semanal.
+- Validacion remota del workflow semanal (rama de validacion): `Weekly KPI Report` run `22407607517` -> `success` (retention/latency/warnings expuestos en resumen; artifact `weekly-kpi-report` generado).
 
 ## Comandos oficiales del plan
 

--- a/REPORTE-SEMANAL-PRODUCCION.ps1
+++ b/REPORTE-SEMANAL-PRODUCCION.ps1
@@ -5,6 +5,10 @@ param(
     [string]$OutputDir = 'verification/weekly',
     [int]$CoreP95MaxMs = 800,
     [int]$FigoPostP95MaxMs = 2500,
+    [double]$NoShowRateWarnPct = 20,
+    [double]$RecurrenceRateMinWarnPct = 30,
+    [double]$RecurrenceRateDropWarnPct = 15,
+    [int]$RecurrenceWarnMinUniquePatients = 5,
     [switch]$FailOnWarnings
 )
 
@@ -597,7 +601,7 @@ if (-not $calendarReachable) {
 if (-not $calendarTokenHealthy) {
     $warnings.Add('calendar_token_unhealthy')
 }
-if ($retentionNoShowRatePct -ge 20) {
+if ($retentionNoShowRatePct -ge $NoShowRateWarnPct) {
     $warnings.Add("no_show_rate_alta_${retentionNoShowRatePct}pct")
 }
 if (-not $sentryBackendConfigured) {
@@ -662,6 +666,18 @@ foreach ($row in $benchResults) {
 $retentionNoShowRateDeltaLabel = if ($null -eq $retentionNoShowRateDeltaPct) { 'n/a' } else { [string]$retentionNoShowRateDeltaPct }
 $retentionRecurrenceRateDeltaLabel = if ($null -eq $retentionRecurrenceRateDeltaPct) { 'n/a' } else { [string]$retentionRecurrenceRateDeltaPct }
 
+$retentionSampleSufficientForRecurrence = $retentionUniquePatients -ge $RecurrenceWarnMinUniquePatients
+if ($retentionSampleSufficientForRecurrence -and $retentionRecurrenceRatePct -lt $RecurrenceRateMinWarnPct) {
+    $warnings.Add("recurrence_rate_baja_${retentionRecurrenceRatePct}pct")
+}
+if (
+    $retentionSampleSufficientForRecurrence -and
+    $null -ne $retentionRecurrenceRateDeltaPct -and
+    $retentionRecurrenceRateDeltaPct -le (-1 * [Math]::Abs($RecurrenceRateDropWarnPct))
+) {
+    $warnings.Add("recurrence_rate_caida_${retentionRecurrenceRateDeltaPct}pct")
+}
+
 $markdown = @"
 # Weekly Production Report - Piel en Armonia
 
@@ -706,6 +722,9 @@ $markdown = @"
 - unique_patients: $retentionUniquePatients
 - recurrent_patients: $retentionRecurrentPatients
 - recurrence_rate_pct: $retentionRecurrenceRatePct
+- recurrence_warning_sample_sufficient: $retentionSampleSufficientForRecurrence (unique_patients >= $RecurrenceWarnMinUniquePatients)
+- recurrence_min_warn_pct: $RecurrenceRateMinWarnPct
+- recurrence_drop_warn_pct: $RecurrenceRateDropWarnPct
 - previous_report_generated_at: $previousReportDate
 - no_show_rate_delta_pct: $retentionNoShowRateDeltaLabel
 - recurrence_rate_delta_pct: $retentionRecurrenceRateDeltaLabel
@@ -763,6 +782,10 @@ $reportPayload = [ordered]@{
         uniquePatients = $retentionUniquePatients
         recurrentPatients = $retentionRecurrentPatients
         recurrenceRatePct = [Math]::Round([double]$retentionRecurrenceRatePct, 2)
+        recurrenceWarningSampleSufficient = [bool]$retentionSampleSufficientForRecurrence
+        recurrenceWarnMinUniquePatients = $RecurrenceWarnMinUniquePatients
+        recurrenceMinWarnPct = [Math]::Round([double]$RecurrenceRateMinWarnPct, 2)
+        recurrenceDropWarnPct = [Math]::Round([double]$RecurrenceRateDropWarnPct, 2)
     }
     retentionTrend = [ordered]@{
         previousReportGeneratedAt = $previousReportDate


### PR DESCRIPTION
## Resumen\n- agrega guardrails configurables de retencion en REPORTE-SEMANAL-PRODUCCION.ps1\n- warning por ecurrence baja y por caida semanal de recurrencia (con sample minimo de pacientes)\n- actualiza evidencia de Fase 6 en plan operativo\n\n## Validacion\n- 
pm run report:weekly:prod (local)\n- corrida forzada local con umbrales de recurrencia para validar warning (ecurrence_rate_baja_*)\n- Weekly KPI Report manual run 22407607517 success (rama de validacion)\n