### PR TITLE
docs(agents): record Fase 6 weekly KPI hardening board evidence

### DIFF
--- a/AGENT_BOARD.yaml
+++ b/AGENT_BOARD.yaml
@@ -3,7 +3,7 @@ policy:
   canonical: AGENTS.md
   autonomy: semi_autonomous_guardrails
   kpi: reduce_rework
-  revision: 34
+  revision: 37
   updated_at: 2026-02-25
 
 tasks:
@@ -1160,5 +1160,39 @@ tasks:
     evidence_ref: "signal_resolved:auto"
     depends_on: []
     prompt: "Reduce post-deploy gate false failures from transient network delays"
+    created_at: 2026-02-25
+    updated_at: 2026-02-25
+
+  - id: AG-034
+    title: "Record Fase 6 weekly KPI hardening evidence in board"
+    owner: Ernesto
+    executor: codex
+    status: done
+    status_since_at: "2026-02-25T17:52:22.997Z"
+    risk: low
+    scope: docs
+    files: ["AGENT_BOARD.yaml", "verification/agent-runs/AG-034.md"]
+    source_signal: manual
+    source_ref: ""
+    priority_score: 0
+    sla_due_at: ""
+    last_attempt_at: ""
+    attempts: 0
+    blocked_reason: ""
+    lease_id: ""
+    lease_owner: ""
+    lease_created_at: ""
+    heartbeat_at: ""
+    lease_expires_at: ""
+    lease_reason: ""
+    lease_cleared_at: "2026-02-25T17:52:22.997Z"
+    lease_cleared_reason: "terminal:done"
+    runtime_impact: low
+    critical_zone: false
+    acceptance: "Record Fase 6 weekly KPI hardening evidence in board"
+    acceptance_ref: "verification/agent-runs/AG-034.md"
+    evidence_ref: "verification/agent-runs/AG-034.md"
+    depends_on: []
+    prompt: "Record Fase 6 weekly KPI hardening evidence in board"
     created_at: 2026-02-25
     updated_at: 2026-02-25

--- a/verification/agent-runs/AG-034.md
+++ b/verification/agent-runs/AG-034.md
@@ -1,0 +1,39 @@
+# AG-034 - Registrar evidencia Fase 6 (Weekly KPI hardening) en board
+
+## Goal
+Reflejar formalmente en `AGENT_BOARD.yaml` el avance de Fase 6 ya mergeado en `main` (retencion + conversion/funnel semanal) con evidencia trazable.
+
+## Alcance documentado
+- Sin cambios runtime nuevos en esta tarea.
+- Se registra evidencia de trabajo ya mergeado:
+  - Guardrails de retencion en `REPORTE-SEMANAL-PRODUCCION.ps1`
+  - Guardrails de conversion final y funnel temprano en `REPORTE-SEMANAL-PRODUCCION.ps1`
+  - Resumen de conversion/funnel en `.github/workflows/weekly-kpi-report.yml`
+  - Actualizaciones de `PLAN_MAESTRO_OPERATIVO_2026.md` y `PLAN_MAESTRO_2026_STATUS.md`
+
+## Evidencia fuente (main)
+- `Weekly KPI Report` run `22408343562` (`main`) -> **success**
+  - Artifact semanal con `conversion.bookingConfirmedRatePct=100`
+  - `conversionTrend.bookingConfirmedRateDeltaPct=null`
+  - `warnings=[]`
+- `Weekly KPI Report` run `22408612570` (`main`) -> **success**
+  - Artifact semanal con `conversion.viewBooking=305`
+  - `conversion.startCheckoutRatePct=0.33`
+  - `conversionTrend.startCheckoutRateDeltaPct=null`
+  - Warning no bloqueante observado: `core_p95_alto_995.16ms`
+
+## Sincronizacion documental (mergeado en main)
+- PR `#294` -> `docs(plan): record weekly conversion and funnel evidence`
+  - Merge commit: `a0abb572873631be9e5fdae766a6463e9c81e9d7`
+- PR `#295` -> `docs(status): sync weekly conversion and funnel hardening evidence`
+  - Merge commit: `d79464abf10e678ab0908b8bdb0bc7d6232d8dc1`
+
+## Validacion local de gobernanza
+- `node agent-orchestrator.js task ls --active --json` -> `matched_active: 0` antes de crear `AG-034`
+- `node agent-orchestrator.js task create --preview --json` -> `AG-034` propuesto sin warnings/errores
+- `node agent-orchestrator.js board doctor --json` -> `ok: true`, `blocking_conflicts: 0`
+- `node agent-orchestrator.js task start AG-034 --status in_progress --json` -> lease creado OK
+
+## Estado
+- `AG-034` cierra trazabilidad de gobernanza para el avance Fase 6 (retencion + conversion/funnel semanal).
+- Pendiente externo sigue siendo Sentry (fuera del alcance de esta tarea).


### PR DESCRIPTION
Agrega tarea AG-034 en AGENT_BOARD.yaml (creada/ejecutada/cerrada por orquestador) y evidencia versionada en verification/agent-runs/AG-034.md para cerrar trazabilidad de gobernanza del hardening semanal de Fase 6 (retencion + conversion/funnel).