### PR TITLE
ci: fast-skip lint for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,30 +17,68 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
+            - name: Detect lint relevant changes
+              id: changes
+              uses: dorny/paths-filter@v3
+              with:
+                  filters: |
+                      lint:
+                        - 'controllers/**'
+                        - 'lib/**'
+                        - 'tests/**'
+                        - 'js/**'
+                        - 'src/**'
+                        - '*.php'
+                        - '*.html'
+                        - '*.css'
+                        - 'package.json'
+                        - 'package-lock.json'
+                        - 'composer.json'
+                        - 'composer.lock'
+                        - 'eslint.config.js'
+                        - 'phpunit.xml'
+                        - 'psalm.xml'
+                        - 'rollup.config.mjs'
+                        - 'playwright.config.js'
+                        - '.github/workflows/ci.yml'
+                        - 'prometheus.docker.yml'
+                        - 'prometheus.rules.yml'
+                        - 'bin/validate-plan-operativo.php'
+                        - 'PLAN_MAESTRO_OPERATIVO_2026.md'
             - name: Setup PHP
+              if: steps.changes.outputs.lint == 'true'
               uses: shivammathur/setup-php@v2
               with:
                   php-version: '8.2'
             - name: Setup Node
+              if: steps.changes.outputs.lint == 'true'
               uses: actions/setup-node@v4
               with:
                   node-version: '20'
                   cache: 'npm'
             - name: Install dependencies
+              if: steps.changes.outputs.lint == 'true'
               run: npm ci
             - name: Lint JS
+              if: steps.changes.outputs.lint == 'true'
               run: npm run lint:js
             - name: Lint PHP
+              if: steps.changes.outputs.lint == 'true'
               run: npm run lint:php
             - name: Validate Plan Operativo anti-loop
+              if: steps.changes.outputs.lint == 'true'
               run: php bin/validate-plan-operativo.php
             - name: Agent Orchestrator status
+              if: steps.changes.outputs.lint == 'true'
               run: node agent-orchestrator.js status
             - name: Agent conflict gate
+              if: steps.changes.outputs.lint == 'true'
               run: node agent-orchestrator.js conflicts --strict
             - name: Validate Agent Governance
+              if: steps.changes.outputs.lint == 'true'
               run: php bin/validate-agent-governance.php
             - name: Lint Prometheus Config
+              if: steps.changes.outputs.lint == 'true'
               run: |
                   docker run --rm \
                     -v $(pwd)/prometheus.docker.yml:/etc/prometheus/prometheus.yml \
@@ -48,6 +86,11 @@ jobs:
                     --entrypoint promtool \
                     prom/prometheus:latest \
                     check config /etc/prometheus/prometheus.yml
+            - name: Skip lint (no relevant changes)
+              if: steps.changes.outputs.lint != 'true'
+              run: |
+                  echo "Skipping lint: no lint-relevant source/config/workflow changes detected."
+                  echo "Docs/board/evidence-only changes should still be covered by Agent Governance checks."
 
     security:
         runs-on: ubuntu-latest

--- a/PLAN_MAESTRO_OPERATIVO_2026.md
+++ b/PLAN_MAESTRO_OPERATIVO_2026.md
@@ -153,6 +153,13 @@ Evidencia parcial (retencion + conversion/funnel):
 - Validacion remota en `main` (post-merge conversion): `Weekly KPI Report` run `22408343562` -> `success` (artifact con `conversion.bookingConfirmedRatePct=100`, `conversionTrend.bookingConfirmedRateDeltaPct=null`, `warnings=[]`).
 - Validacion remota en `main` (post-merge funnel temprano): `Weekly KPI Report` run `22408612570` -> `success` (artifact con `conversion.viewBooking=305`, `conversion.startCheckoutRatePct=0.33`, `conversionTrend.startCheckoutRateDeltaPct=null`; warning no bloqueante `core_p95_alto_995.16ms`).
 
+### Disciplina de ejecucion (Codex, 2026-02-25)
+
+- Modo por bloques: 45-90 min por objetivo, `1 PR` por bloque (cambio tecnico + evidencia/docs si aplica).
+- Validacion remota por hitos: checks locales durante el bloque; `CI/PR checks` y workflows manuales solo al cierre del bloque.
+- Evitar micro-PRs de sincronizacion (`plan/status/board`) inmediatamente despues del PR tecnico; cerrar evidencia en lote en el mismo PR o en un unico PR de cierre de sesion.
+- `Weekly KPI Report` manual: ejecutar una sola vez por bloque que modifique el reporte semanal (no por subcambio).
+
 ## Comandos oficiales del plan
 
 - Validacion backend bloqueante: `npm run gate:prod:backend`


### PR DESCRIPTION
## Bloque 1 (reduccion de overhead CI/docs)\n- agrega paths-filter al job lint en .github/workflows/ci.yml\n- lint ahora hace fast-skip en cambios solo docs/board/evidence (sin codigo/config relevantes)\n- mantiene Agent Governance como workflow separado para PRs de docs/board\n- documenta disciplina de ejecucion por bloques/validacion por hitos en PLAN_MAESTRO_OPERATIVO_2026.md\n\n## Validacion local\n- 
px prettier --check .github/workflows/ci.yml PLAN_MAESTRO_OPERATIVO_2026.md\n\n## Nota\nDespues del merge, hare una PR docs-only minima para verificar el comportamiento de skip de lint y comparar con baseline (run 22409249156).