### PR TITLE
ops(kpi): classify weekly warnings by severity

### DIFF
--- a/.github/workflows/weekly-kpi-report.yml
+++ b/.github/workflows/weekly-kpi-report.yml
@@ -16,7 +16,7 @@ on:
                 default: '15'
                 type: string
             fail_on_warnings:
-                description: 'Fallar workflow si hay warnings de KPI'
+                description: 'Fallar workflow si hay warnings criticos de KPI'
                 required: false
                 default: true
                 type: boolean
@@ -60,7 +60,7 @@ jobs:
                   $benchRuns = [int]$env:BENCH_RUNS
                   if ($benchRuns -lt 5) { $benchRuns = 5 }
                   if ($env:FAIL_ON_WARNINGS -eq 'true') {
-                    & ./REPORTE-SEMANAL-PRODUCCION.ps1 -Domain $env:TARGET_DOMAIN -BenchRuns $benchRuns -FailOnWarnings
+                    & ./REPORTE-SEMANAL-PRODUCCION.ps1 -Domain $env:TARGET_DOMAIN -BenchRuns $benchRuns -FailOnCriticalWarnings
                   } else {
                     & ./REPORTE-SEMANAL-PRODUCCION.ps1 -Domain $env:TARGET_DOMAIN -BenchRuns $benchRuns
                   }
@@ -79,6 +79,10 @@ jobs:
                     "report_md_path=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
                     "warnings_count=-1" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
                     "warnings_list=n/a" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+                    "warnings_critical_count=-1" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+                    "warnings_critical_list=n/a" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+                    "warnings_non_critical_count=-1" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+                    "warnings_non_critical_list=n/a" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
                     "conversion_view_booking=n/a" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
                     "conversion_start_checkout=n/a" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
                     "conversion_start_checkout_rate_pct=n/a" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
@@ -102,6 +106,10 @@ jobs:
                   $jsonPath = $latestJson.FullName
                   $mdPath = [System.IO.Path]::ChangeExtension($jsonPath, '.md')
                   $warningsCount = 0
+                  $warningsCriticalCount = 0
+                  $warningsNonCriticalCount = 0
+                  $warningsCriticalList = 'none'
+                  $warningsNonCriticalList = 'none'
 
                   try {
                     $payload = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json -Depth 10
@@ -109,6 +117,24 @@ jobs:
                       $warningsCount = @($payload.warnings).Count
                     }
                     $warningsList = if ($payload.warnings) { (@($payload.warnings) -join ', ') } else { 'none' }
+                    if ($null -ne $payload.warningCounts) {
+                      if ($null -ne $payload.warningCounts.critical) { $warningsCriticalCount = [int]$payload.warningCounts.critical }
+                      if ($null -ne $payload.warningCounts.nonCritical) { $warningsNonCriticalCount = [int]$payload.warningCounts.nonCritical }
+                    } elseif ($null -ne $payload.warningsBySeverity) {
+                      $warningsCriticalCount = if ($payload.warningsBySeverity.critical) { @($payload.warningsBySeverity.critical).Count } else { 0 }
+                      $warningsNonCriticalCount = if ($payload.warningsBySeverity.nonCritical) { @($payload.warningsBySeverity.nonCritical).Count } else { 0 }
+                    } elseif ($payload.warnings) {
+                      # Fallback conservador para reportes viejos sin severidad.
+                      $warningsCriticalCount = @($payload.warnings).Count
+                      $warningsNonCriticalCount = 0
+                    }
+                    if ($null -ne $payload.warningsBySeverity) {
+                      $warningsCriticalList = if ($payload.warningsBySeverity.critical) { (@($payload.warningsBySeverity.critical) -join ', ') } else { 'none' }
+                      $warningsNonCriticalList = if ($payload.warningsBySeverity.nonCritical) { (@($payload.warningsBySeverity.nonCritical) -join ', ') } else { 'none' }
+                    } else {
+                      $warningsCriticalList = $warningsList
+                      $warningsNonCriticalList = 'none'
+                    }
 
                     $retention = $payload.retention
                     $retentionTrend = $payload.retentionTrend
@@ -154,6 +180,10 @@ jobs:
                   } catch {
                     $warningsCount = -1
                     $warningsList = 'n/a'
+                    $warningsCriticalCount = -1
+                    $warningsNonCriticalCount = -1
+                    $warningsCriticalList = 'n/a'
+                    $warningsNonCriticalList = 'n/a'
                     $conversionViewBooking = 'n/a'
                     $conversionStartCheckout = 'n/a'
                     $conversionStartCheckoutRate = 'n/a'
@@ -177,6 +207,10 @@ jobs:
                   "report_md_path=$mdPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
                   "warnings_count=$warningsCount" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
                   "warnings_list=$warningsList" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+                  "warnings_critical_count=$warningsCriticalCount" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+                  "warnings_critical_list=$warningsCriticalList" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+                  "warnings_non_critical_count=$warningsNonCriticalCount" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+                  "warnings_non_critical_list=$warningsNonCriticalList" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
                   "conversion_view_booking=$conversionViewBooking" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
                   "conversion_start_checkout=$conversionStartCheckout" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
                   "conversion_start_checkout_rate_pct=$conversionStartCheckoutRate" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
@@ -214,9 +248,13 @@ jobs:
                   Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Weekly KPI report"
                   Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Dominio: ``$env:TARGET_DOMAIN``"
                   Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Bench runs: ``$env:BENCH_RUNS``"
-                  Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Fail on warnings: ``$env:FAIL_ON_WARNINGS``"
+                  Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Fail on warnings (critical-only gate): ``$env:FAIL_ON_WARNINGS``"
                   Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Warnings count: ``${{ steps.report.outputs.warnings_count }}``"
+                  Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Warnings critical: ``${{ steps.report.outputs.warnings_critical_count }}``"
+                  Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Warnings non_critical: ``${{ steps.report.outputs.warnings_non_critical_count }}``"
                   Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Warnings: ``${{ steps.report.outputs.warnings_list }}``"
+                  Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Warnings critical list: ``${{ steps.report.outputs.warnings_critical_list }}``"
+                  Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Warnings non_critical list: ``${{ steps.report.outputs.warnings_non_critical_list }}``"
                   Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Agent metrics file: ``verification/agent-metrics.json``"
                   Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ""
                   Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Conversion"
@@ -242,7 +280,7 @@ jobs:
                   }
 
             - name: Crear/actualizar incidente semanal
-              if: ${{ failure() && github.event_name == 'schedule' }}
+              if: ${{ github.event_name == 'schedule' && (steps.report.outputs.warnings_critical_count == '-1' || steps.report.outputs.warnings_critical_count != '0') }}
               uses: actions/github-script@v7
               with:
                   script: |
@@ -252,12 +290,17 @@ jobs:
                       const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
                       const now = new Date().toISOString();
                       const body = [
-                        'El workflow `Weekly KPI Report` fallo o detecto warnings en ejecucion programada.',
+                        'El workflow `Weekly KPI Report` fallo o detecto warnings criticos en ejecucion programada.',
                         '',
                         `- Fecha: ${now}`,
                         `- Run: ${runUrl}`,
                         `- Workflow: ${context.workflow}`,
-                        `- Branch: ${context.ref}`
+                        `- Branch: ${context.ref}`,
+                        `- warnings_count: ${{ steps.report.outputs.warnings_count }}`,
+                        `- warnings_critical_count: ${{ steps.report.outputs.warnings_critical_count }}`,
+                        `- warnings_non_critical_count: ${{ steps.report.outputs.warnings_non_critical_count }}`,
+                        `- warnings_critical_list: ${{ steps.report.outputs.warnings_critical_list }}`,
+                        `- warnings_non_critical_list: ${{ steps.report.outputs.warnings_non_critical_list }}`
                       ].join('\n');
 
                       const openIssues = await github.paginate(github.rest.issues.listForRepo, {
@@ -287,7 +330,7 @@ jobs:
                       }
 
             - name: Cerrar incidente semanal al recuperar
-              if: ${{ success() && github.event_name == 'schedule' }}
+              if: ${{ success() && github.event_name == 'schedule' && steps.report.outputs.warnings_critical_count == '0' }}
               uses: actions/github-script@v7
               with:
                   script: |

--- a/REPORTE-SEMANAL-PRODUCCION.ps1
+++ b/REPORTE-SEMANAL-PRODUCCION.ps1
@@ -15,7 +15,8 @@ param(
     [double]$StartCheckoutRateMinWarnPct = 0.25,
     [double]$StartCheckoutRateDropWarnPct = 0.2,
     [int]$StartCheckoutWarnMinViewBooking = 100,
-    [switch]$FailOnWarnings
+    [switch]$FailOnWarnings,
+    [switch]$FailOnCriticalWarnings
 )
 
 $ErrorActionPreference = 'Stop'
@@ -55,6 +56,49 @@ function Read-JsonFileSafe {
     } catch {
         return $null
     }
+}
+
+function Get-WarningSeverity {
+    param([string]$WarningCode)
+
+    if ([string]::IsNullOrWhiteSpace($WarningCode)) {
+        return 'critical'
+    }
+
+    if (
+        $WarningCode -eq 'calendar_unreachable' -or
+        $WarningCode -eq 'calendar_token_unhealthy' -or
+        $WarningCode -eq 'sentry_backend_no_configurado' -or
+        $WarningCode -eq 'sentry_frontend_no_configurado'
+    ) {
+        return 'critical'
+    }
+
+    foreach ($prefix in @(
+        'error_rate_alta_',
+        'calendar_source_',
+        'calendar_mode_'
+    )) {
+        if ($WarningCode.StartsWith($prefix)) {
+            return 'critical'
+        }
+    }
+
+    foreach ($prefix in @(
+        'core_p95_alto_',
+        'figo_post_p95_alto_',
+        'no_show_rate_alta_',
+        'recurrence_rate_',
+        'conversion_rate_',
+        'start_checkout_rate_'
+    )) {
+        if ($WarningCode.StartsWith($prefix)) {
+            return 'non_critical'
+        }
+    }
+
+    # Default conservador: si aparece un warning nuevo no clasificado, tratarlo como critico.
+    return 'critical'
 }
 
 function Invoke-JsonGet {
@@ -766,6 +810,19 @@ if (
 ) {
     $warnings.Add("start_checkout_rate_caida_${startCheckoutRateDeltaPct}pct")
 }
+$warningsCritical = New-Object System.Collections.Generic.List[string]
+$warningsNonCritical = New-Object System.Collections.Generic.List[string]
+foreach ($warningCode in $warnings) {
+    $warningSeverity = Get-WarningSeverity -WarningCode $warningCode
+    if ($warningSeverity -eq 'non_critical') {
+        $warningsNonCritical.Add($warningCode)
+    } else {
+        $warningsCritical.Add($warningCode)
+    }
+}
+$warningCountsTotal = $warnings.Count
+$warningCountsCritical = $warningsCritical.Count
+$warningCountsNonCritical = $warningsNonCritical.Count
 $warningBlock = if ($warnings.Count -eq 0) {
     '- none'
 } else {
@@ -845,6 +902,10 @@ $markdown = @"
 $($benchTable -join "`n")
 
 ## Warnings
+
+- warnings_total: $warningCountsTotal
+- warnings_critical: $warningCountsCritical
+- warnings_non_critical: $warningCountsNonCritical
 
 $warningBlock
 "@
@@ -930,6 +991,17 @@ $reportPayload = [ordered]@{
         figoPostP95TargetMs = $FigoPostP95MaxMs
         bench = $benchResults
     }
+    warningCounts = [ordered]@{
+        total = $warningCountsTotal
+        critical = $warningCountsCritical
+        nonCritical = $warningCountsNonCritical
+    }
+    warningsBySeverity = [ordered]@{
+        critical = @($warningsCritical)
+        nonCritical = @($warningsNonCritical)
+    }
+    warningsCritical = @($warningsCritical)
+    warningsNonCritical = @($warningsNonCritical)
     warnings = @($warnings)
 }
 $reportPayload | ConvertTo-Json -Depth 10 | Set-Content -Path $reportJsonPath -Encoding UTF8
@@ -941,9 +1013,17 @@ Write-Host "start_checkout_rate_pct=$startCheckoutRatePct booking_confirmed=$boo
 Write-Host "retention_no_show_rate_pct=$retentionNoShowRatePct retention_recurrence_rate_pct=$retentionRecurrenceRatePct sentry_backend=$sentryBackendConfigured sentry_frontend=$sentryFrontendConfigured"
 if ($warnings.Count -gt 0) {
     Write-Host "Warnings: $($warnings -join ', ')" -ForegroundColor Yellow
+    Write-Host "Warnings by severity: critical=$warningCountsCritical non_critical=$warningCountsNonCritical" -ForegroundColor Yellow
     if ($FailOnWarnings) {
         Write-Host 'FailOnWarnings activo: reporte marcado como fallido.' -ForegroundColor Red
         exit 2
+    }
+    if ($FailOnCriticalWarnings -and $warningCountsCritical -gt 0) {
+        Write-Host 'FailOnCriticalWarnings activo: reporte marcado como fallido por warnings criticos.' -ForegroundColor Red
+        exit 2
+    }
+    if ($FailOnCriticalWarnings -and $warningCountsCritical -eq 0) {
+        Write-Host 'FailOnCriticalWarnings activo: solo se detectaron warnings no criticos.' -ForegroundColor Yellow
     }
 } else {
     Write-Host 'Warnings: none' -ForegroundColor Green


### PR DESCRIPTION
## Cambio\n- clasifica warnings del reporte semanal en critical/non_critical (payload compatible hacia atras)\n- muestra conteos/listas por severidad en el workflow semanal\n- incidenta semanalmente solo si hay warnings criticos o fallo de parseo\n- gate de fail_on_warnings pasa a modo critico-only para reducir ruido de latencia\n\n## Validacion local\n- pwsh parse OK del script\n- prettier check del workflow OK\n- corrida normal: warnings none\n- corrida forzada con core_p95 warning + -FailOnCriticalWarnings: exit 0 con non_critical=1