### PR TITLE
fix(ci): restore post-deploy gate workflow dispatch parsing

### DIFF
--- a/.github/workflows/post-deploy-gate.yml
+++ b/.github/workflows/post-deploy-gate.yml
@@ -119,8 +119,6 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 2
-              with:
-                  fetch-depth: 2
 
             - name: Esperar sincronizacion Git del hosting
               if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Summary\n- remove duplicated \with:\ key in checkout step of \.github/workflows/post-deploy-gate.yml\\n- restore GitHub Actions YAML parsing so manual dispatch works again\n\n## Validation\n- npx prettier --check .github/workflows/post-deploy-gate.yml\n