### PR TITLE
Refactor: Remove unused encryption logic in storage.php

### DIFF
--- a/lib/storage.php
+++ b/lib/storage.php
@@ -345,8 +345,7 @@ function ensure_json_store_file(): bool
         return false;
     }
 
-    $encoded = data_encrypt_payload($raw);
-    return @file_put_contents($jsonPath, $encoded, LOCK_EX) !== false;
+    return @file_put_contents($jsonPath, $raw, LOCK_EX) !== false;
 }
 
 function read_store_json_fallback(): array
@@ -394,14 +393,7 @@ function write_store_json_fallback(array $store): bool
         return false;
     }
 
-    $encoded = data_encrypt_payload($raw);
-    return @file_put_contents($jsonPath, $encoded, LOCK_EX) !== false;
-}
-
-// Encryption functions retained for legacy support if needed, but not used for SQLite directly
-function data_encrypt_payload(string $plain): string
-{
-    return $plain;
+    return @file_put_contents($jsonPath, $raw, LOCK_EX) !== false;
 }
 
 function data_encryption_key(): string

--- a/tests/test_storage_json_fallback.php
+++ b/tests/test_storage_json_fallback.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+// Set up temporary environment for testing
+$tmpDataDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pielarmonia-test-json-fallback-' . uniqid();
+putenv("PIELARMONIA_DATA_DIR=$tmpDataDir");
+putenv("PIELARMONIA_STORAGE_JSON_FALLBACK=true");
+
+// Include dependencies
+require_once __DIR__ . '/../lib/common.php';
+require_once __DIR__ . '/../lib/validation.php';
+require_once __DIR__ . '/../lib/storage.php';
+
+echo "Testing Storage JSON Fallback (Refactoring Verification)...\n";
+echo "Using temp data dir: $tmpDataDir\n";
+
+if (is_dir($tmpDataDir)) {
+    exec("rm -rf " . escapeshellarg($tmpDataDir));
+}
+mkdir($tmpDataDir, 0777, true);
+
+// Test 1: ensure_json_store_file creates valid JSON
+echo "Test 1: ensure_json_store_file...\n";
+if (!ensure_json_store_file()) {
+    echo "FAIL: ensure_json_store_file returned false\n";
+    exit(1);
+}
+
+$jsonPath = $tmpDataDir . '/store.json';
+if (!file_exists($jsonPath)) {
+    echo "FAIL: store.json not created\n";
+    exit(1);
+}
+
+$content = file_get_contents($jsonPath);
+$json = json_decode($content, true);
+if (!is_array($json)) {
+    echo "FAIL: store.json content is not valid JSON\n";
+    echo "Content: " . substr($content, 0, 100) . "...\n";
+    exit(1);
+}
+
+if (!isset($json['updatedAt'])) {
+    echo "FAIL: store.json missing updatedAt\n";
+    exit(1);
+}
+echo "PASS: ensure_json_store_file created valid JSON\n";
+
+// Test 2: write_store_json_fallback updates valid JSON
+echo "Test 2: write_store_json_fallback...\n";
+$payload = [
+    'appointments' => [
+        ['id' => 1, 'name' => 'Test User']
+    ],
+    'updatedAt' => local_date('c')
+];
+
+if (!write_store_json_fallback($payload)) {
+    echo "FAIL: write_store_json_fallback returned false\n";
+    exit(1);
+}
+
+$content = file_get_contents($jsonPath);
+$json = json_decode($content, true);
+if (!is_array($json)) {
+    echo "FAIL: store.json content is not valid JSON after write\n";
+    echo "Content: " . substr($content, 0, 100) . "...\n";
+    exit(1);
+}
+
+if (!isset($json['appointments']) || count($json['appointments']) !== 1) {
+    echo "FAIL: store.json missing appointments\n";
+    print_r($json);
+    exit(1);
+}
+
+if ($json['appointments'][0]['name'] !== 'Test User') {
+    echo "FAIL: store.json content mismatch\n";
+    exit(1);
+}
+
+echo "PASS: write_store_json_fallback updated valid JSON\n";
+
+// Cleanup
+exec("rm -rf " . escapeshellarg($tmpDataDir));
+echo "All tests passed.\n";

--- a/tests/verify-api-lib.php
+++ b/tests/verify-api-lib.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../api-lib.php';
 $functions = [
     'local_date', 'app_runtime_version', 'data_dir_path', 'data_file_path', 'data_dir_writable',
     'store_file_is_encrypted', 'backup_dir_path', 'audit_log_file_path', 'data_encryption_key',
-    'data_encrypt_payload', 'data_decrypt_payload', 'audit_log_event', 'json_response',
+    'data_decrypt_payload', 'audit_log_event', 'json_response',
     'is_https_request', 'start_secure_session', 'destroy_secure_session', 'ensure_backup_dir',
     'prune_backup_files', 'create_store_backup_locked', 'ensure_data_htaccess', 'ensure_data_file',
     'read_store', 'write_store', 'acquire_store_lock', 'sanitize_phone', 'validate_email',


### PR DESCRIPTION
Removed `data_encrypt_payload` from `lib/storage.php` as it was unused (no-op). Updated calling functions `ensure_json_store_file` and `write_store_json_fallback` to write data directly. Updated `tests/verify-api-lib.php` and added `tests/test_storage_json_fallback.php` to verify changes.

---
*PR created automatically by Jules for task [10062050538219510517](https://jules.google.com/task/10062050538219510517) started by @erosero558558*