### PR TITLE
🔒 Fix rate limit bypass via X-Forwarded-For spoofing

### DIFF
--- a/env.example.php
+++ b/env.example.php
@@ -105,6 +105,12 @@
 // ── Cron (recordatorios automáticos) ────────────────
 // putenv('PIELARMONIA_CRON_SECRET=un_token_secreto_largo');
 // ── Rate limit (IP + usuario) ────────────────────────
+// Proxies de confianza (para usar X-Forwarded-For).
+// Por seguridad, X-Forwarded-For se ignora si la peticion no viene de una IP confiable.
+// Default: 127.0.0.1,::1 (localhost).
+// Si usas Cloudflare o Load Balancer, agrega sus IPs (CIDR soportado).
+// putenv('PIELARMONIA_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16');
+
 // Habilita limite adicional por usuario/token (default true).
 // putenv('PIELARMONIA_RATE_LIMIT_PER_USER_ENABLED=true');
 // Max requests por usuario/token en la ventana (default = maxRequests del endpoint).

--- a/lib/ratelimit.php
+++ b/lib/ratelimit.php
@@ -11,6 +11,18 @@ declare(strict_types=1);
  */
 function rate_limit_client_ip(): string
 {
+    $remoteAddr = $_SERVER['REMOTE_ADDR'] ?? null;
+    if (!is_string($remoteAddr) || trim($remoteAddr) === '') {
+        return 'unknown';
+    }
+
+    $remoteAddr = trim($remoteAddr);
+
+    // If REMOTE_ADDR is not a trusted proxy, we do NOT trust headers.
+    if (!rate_limit_is_trusted_proxy($remoteAddr)) {
+        return filter_var($remoteAddr, FILTER_VALIDATE_IP) !== false ? $remoteAddr : 'unknown';
+    }
+
     $candidates = [
         $_SERVER['HTTP_CF_CONNECTING_IP'] ?? null,
         $_SERVER['HTTP_X_REAL_IP'] ?? null,
@@ -23,7 +35,7 @@ function rate_limit_client_ip(): string
         $candidates[] = $first;
     }
 
-    $candidates[] = $_SERVER['REMOTE_ADDR'] ?? null;
+    $candidates[] = $remoteAddr;
 
     foreach ($candidates as $candidate) {
         if (!is_string($candidate) || trim($candidate) === '') {
@@ -37,6 +49,69 @@ function rate_limit_client_ip(): string
     }
 
     return 'unknown';
+}
+
+/**
+ * Checks if an IP is a trusted proxy.
+ */
+function rate_limit_is_trusted_proxy(string $ip): bool
+{
+    $trusted = getenv('PIELARMONIA_TRUSTED_PROXIES');
+    if (!is_string($trusted) || trim($trusted) === '') {
+        // Default to trusting localhost only if not configured
+        $trusted = '127.0.0.1,::1';
+    }
+
+    $trusted = trim($trusted);
+    if ($trusted === '*') {
+        return true;
+    }
+
+    $proxies = explode(',', $trusted);
+    foreach ($proxies as $proxy) {
+        $proxy = trim($proxy);
+        if ($proxy === '') {
+            continue;
+        }
+        if (rate_limit_ip_in_range($ip, $proxy)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Checks if an IP is in a CIDR range.
+ */
+function rate_limit_ip_in_range(string $ip, string $range): bool
+{
+    if (strpos($range, '/') === false) {
+        return $ip === $range;
+    }
+
+    [$subnet, $bits] = explode('/', $range, 2);
+    $ip = @inet_pton($ip);
+    $subnet = @inet_pton($subnet);
+
+    if ($ip === false || $subnet === false) {
+        return false;
+    }
+
+    // Check if IP versions match
+    if (strlen($ip) !== strlen($subnet)) {
+        return false;
+    }
+
+    $bits = (int) $bits;
+    // Calculate mask
+    $mask = str_repeat("\xFF", (int)($bits / 8));
+    if (($bits % 8) > 0) {
+        $mask .= chr(0xFF << (8 - ($bits % 8)));
+    }
+    $mask = str_pad($mask, strlen($ip), "\x00");
+
+    return ($ip & $mask) === ($subnet & $mask);
 }
 
 /**

--- a/tests/test_ratelimit_hardening.php
+++ b/tests/test_ratelimit_hardening.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 $tempDir = __DIR__ . '/temp_ratelimit_data';
 putenv("PIELARMONIA_DATA_DIR=$tempDir");
+putenv("PIELARMONIA_TRUSTED_PROXIES=10.10.10.10");
 
 if (is_dir($tempDir)) {
     $it = new RecursiveDirectoryIterator($tempDir, RecursiveDirectoryIterator::SKIP_DOTS);


### PR DESCRIPTION
Fixes a security vulnerability where rate limits could be bypassed by spoofing `X-Forwarded-For` headers. The fix involves validating the `REMOTE_ADDR` against a configured list of trusted proxies (`PIELARMONIA_TRUSTED_PROXIES`) before honoring forwarded headers. If the request does not come from a trusted proxy, only `REMOTE_ADDR` is used for rate limiting. CIDR notation is supported for trusted proxies. `env.example.php` has been updated with instructions.

---
*PR created automatically by Jules for task [3477002853332860678](https://jules.google.com/task/3477002853332860678) started by @erosero558558*