### PR TITLE
Fix: Encrypt JSON storage fallback to prevent plaintext data exposure

### DIFF
--- a/lib/storage.php
+++ b/lib/storage.php
@@ -401,7 +401,30 @@ function write_store_json_fallback(array $store): bool
 // Encryption functions retained for legacy support if needed, but not used for SQLite directly
 function data_encrypt_payload(string $plain): string
 {
-    return $plain;
+    $key = data_encryption_key();
+    if ($key === '') {
+        return $plain;
+    }
+
+    if (!function_exists('openssl_encrypt')) {
+        return $plain;
+    }
+
+    try {
+        $iv = random_bytes(12);
+    } catch (Exception $e) {
+        $iv = openssl_random_pseudo_bytes(12);
+    }
+
+    $tag = '';
+    $cipher = openssl_encrypt($plain, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
+
+    if ($cipher === false) {
+        return '';
+    }
+
+    $packed = $iv . $tag . $cipher;
+    return 'ENCv1:' . base64_encode($packed);
 }
 
 function data_encryption_key(): string

--- a/tests/test_storage_encryption.php
+++ b/tests/test_storage_encryption.php
@@ -1,0 +1,70 @@
+<?php
+
+require_once __DIR__ . '/test_framework.php';
+
+// Set up temporary environment for testing
+$tmpDataDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pielarmonia-test-encryption-' . uniqid();
+putenv("PIELARMONIA_DATA_DIR=$tmpDataDir");
+
+// We set the key to verify encryption works
+$testKey = 'test_key_123456789012345678901234'; // 32 chars
+putenv("PIELARMONIA_DATA_ENCRYPTION_KEY=$testKey");
+putenv("PIELARMONIA_STORAGE_JSON_FALLBACK=true");
+
+if (is_dir($tmpDataDir)) {
+    exec("rm -rf " . escapeshellarg($tmpDataDir));
+}
+mkdir($tmpDataDir, 0777, true);
+
+require_once __DIR__ . '/../lib/storage.php';
+
+echo "Testing Storage Encryption Logic...\n";
+echo "Using temp data dir: $tmpDataDir\n";
+
+run_test('data_encrypt_payload should return encrypted string when key is present', function () {
+    $plain = 'Sensitive Data';
+    $encrypted = data_encrypt_payload($plain);
+
+    assert_true($encrypted !== $plain, 'Encrypted string should not match plaintext');
+    assert_true(strpos($encrypted, 'ENCv1:') === 0, 'Encrypted string should start with ENCv1:');
+
+    // Verify length logic (ENCv1: + base64(12+16+len))
+    assert_greater_than(20, strlen($encrypted), 'Encrypted string should have substantial length');
+});
+
+run_test('data_decrypt_payload should decrypt correctly', function () {
+    $plain = 'Another Secret';
+    $encrypted = data_encrypt_payload($plain);
+    $decrypted = data_decrypt_payload($encrypted);
+
+    assert_equals($plain, $decrypted, 'Decrypted string should match original plaintext');
+});
+
+run_test('write_store_json_fallback should write encrypted file', function () use ($tmpDataDir) {
+    $store = ['appointments' => [['id' => 1, 'name' => 'Secret Patient']]];
+
+    // Ensure file doesn't exist
+    $jsonPath = $tmpDataDir . '/store.json';
+    if (file_exists($jsonPath)) unlink($jsonPath);
+
+    $result = write_store_json_fallback($store);
+    assert_true($result, 'write_store_json_fallback should return true');
+
+    assert_true(file_exists($jsonPath), 'store.json should be created');
+
+    $content = file_get_contents($jsonPath);
+    assert_true(strpos($content, 'ENCv1:') === 0, 'store.json content should start with ENCv1:');
+    assert_false(strpos($content, 'Secret Patient'), 'store.json should not contain plaintext data');
+
+    // Verify we can read it back
+    // We need to clear static cache or ensure environment is correct?
+    // read_store_json_fallback uses data_decrypt_payload which uses data_encryption_key().
+    // Since we are in same process, data_encryption_key() is already resolved with our key.
+    $readStore = read_store_json_fallback();
+    assert_equals('Secret Patient', $readStore['appointments'][0]['name'] ?? null, 'Should be able to read back decrypted data');
+});
+
+// Cleanup
+exec("rm -rf " . escapeshellarg($tmpDataDir));
+
+print_test_summary();


### PR DESCRIPTION
Implemented AES-256-GCM encryption for the JSON storage fallback mechanism to fix a security vulnerability where sensitive data was stored in plaintext. Added a regression test case.

---
*PR created automatically by Jules for task [5549514396927489687](https://jules.google.com/task/5549514396927489687) started by @erosero558558*