### PR TITLE
Fix IDOR vulnerability in record creation

### DIFF
--- a/controllers/CallbackController.php
+++ b/controllers/CallbackController.php
@@ -20,6 +20,8 @@ class CallbackController
         $store = $context['store'];
         require_rate_limit('callbacks', 5, 60);
         $payload = require_json_body();
+        // Security: ensure we generate a new ID for new callbacks
+        unset($payload['id']);
         $callback = normalize_callback($payload);
 
         if ($callback['telefono'] === '') {

--- a/controllers/ReviewController.php
+++ b/controllers/ReviewController.php
@@ -32,6 +32,8 @@ class ReviewController
         $store = $context['store'];
         require_rate_limit('reviews', 3, 60);
         $payload = require_json_body();
+        // Security: ensure we generate a new ID for new reviews
+        unset($payload['id']);
         $review = normalize_review($payload);
         if ($review['name'] === '' || $review['text'] === '') {
             json_response([

--- a/lib/BookingService.php
+++ b/lib/BookingService.php
@@ -17,6 +17,8 @@ class BookingService
      */
     public function create(array $store, array $payload): array
     {
+        // Security: ensure we generate a new ID for new appointments
+        unset($payload['id']);
         $appointment = normalize_appointment($payload);
 
         $validation = validate_appointment_payload($appointment, [


### PR DESCRIPTION
Fixed an Insecure Direct Object Reference (IDOR) vulnerability that allowed attackers to overwrite existing appointments, reviews, or callbacks by including an `id` field in the creation payload. The backend logic previously accepted this ID and used it in an `INSERT OR REPLACE` operation. The fix involves explicitly unsetting the `id` field from the input payload in `BookingService::create`, `ReviewController::store`, and `CallbackController::store` before data normalization, ensuring that a new ID is always generated for new records. Verified with a reproduction script and existing integration tests.

---
*PR created automatically by Jules for task [1855059255161097916](https://jules.google.com/task/1855059255161097916) started by @erosero558558*