### PR TITLE
Fix fail function signature in disaster recovery test

### DIFF
--- a/tests/Integration/verify_disaster_recovery.php
+++ b/tests/Integration/verify_disaster_recovery.php
@@ -32,14 +32,14 @@ require_once __DIR__ . '/../../lib/db.php';
 $storeFile = data_file_path();
 require_once __DIR__ . '/../../lib/backup.php';
 
-function fail($msg, $dir)
+function fail($msg, $dir = null)
 {
-    // Fix: Access global tempDir properly
     global $tempDir;
     echo "FAILED: $msg\n";
     // Cleanup
-    if (isset($tempDir)) {
-        recursiveRemove($tempDir);
+    $cleanupDir = $dir ?? $tempDir;
+    if (isset($cleanupDir)) {
+        recursiveRemove($cleanupDir);
     }
     exit(1);
 }


### PR DESCRIPTION
Fixes a latent bug in `tests/Integration/verify_disaster_recovery.php` where the `fail` helper function had a mandatory unused argument, causing potential crashes during test failures.

---
*PR created automatically by Jules for task [18192747240803286861](https://jules.google.com/task/18192747240803286861) started by @erosero558558*