### PR TITLE
Add unit tests for app_runtime_version

### DIFF
--- a/tests/Unit/CommonTest.php
+++ b/tests/Unit/CommonTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/common.php';
+
+class CommonTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAppRuntimeVersionPriority(): void
+    {
+        putenv('PIELARMONIA_APP_VERSION=v1.0.0');
+        putenv('APP_VERSION=v2.0.0');
+
+        $this->assertSame('v1.0.0', app_runtime_version());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAppRuntimeVersionFallback(): void
+    {
+        putenv('PIELARMONIA_APP_VERSION');
+        putenv('APP_VERSION=v2.0.0');
+
+        $this->assertSame('v2.0.0', app_runtime_version());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAppRuntimeVersionFileMtime(): void
+    {
+        putenv('PIELARMONIA_APP_VERSION');
+        putenv('APP_VERSION');
+
+        $version = app_runtime_version();
+
+        // Should return a 14-digit timestamp since files exist
+        $this->assertMatchesRegularExpression('/^\d{14}$/', $version);
+    }
+}


### PR DESCRIPTION
Added `tests/Unit/CommonTest.php` to test `app_runtime_version` in `lib/common.php`.
Tests cover:
- Priority of `PIELARMONIA_APP_VERSION` over `APP_VERSION`.
- Fallback to `APP_VERSION` when `PIELARMONIA_APP_VERSION` is unset.
- Fallback to timestamp based on file modification time when no environment variables are set.

---
*PR created automatically by Jules for task [11509769528228791726](https://jules.google.com/task/11509769528228791726) started by @erosero558558*