### PR TITLE
Add tests for same-day booking validation

### DIFF
--- a/lib/validation.php
+++ b/lib/validation.php
@@ -162,7 +162,7 @@ function validate_time_format(string $time): bool
  *
  * @return array ['ok' => bool, 'error' => string|null]
  */
-function validate_future_date(string $date, string $time): array
+function validate_future_date(string $date, string $time, ?string $currentDate = null, ?string $currentTime = null): array
 {
     if ($date === '' || $time === '') {
         return ['ok' => false, 'error' => 'Fecha y hora son obligatorias'];
@@ -176,13 +176,19 @@ function validate_future_date(string $date, string $time): array
         return ['ok' => false, 'error' => 'Formato de hora inválido (HH:MM)'];
     }
 
-    $today = local_date('Y-m-d');
+    $today = $currentDate ?? local_date('Y-m-d');
     if ($date < $today) {
         return ['ok' => false, 'error' => 'No se puede agendar en una fecha pasada'];
     }
 
     if ($date === $today) {
-        $nowMinutes = (int) local_date('H') * 60 + (int) local_date('i');
+        if ($currentTime !== null) {
+            $partsNow = explode(':', $currentTime);
+            $nowMinutes = (int) ($partsNow[0] ?? 0) * 60 + (int) ($partsNow[1] ?? 0);
+        } else {
+            $nowMinutes = (int) local_date('H') * 60 + (int) local_date('i');
+        }
+
         $parts = explode(':', $time);
         $slotMinutes = (int) ($parts[0] ?? 0) * 60 + (int) ($parts[1] ?? 0);
         // Allow booking only 1 hour ahead

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -30,10 +30,40 @@ class ValidationTest extends TestCase
         $result = validate_future_date('2025-01-01', 'invalid');
         $this->assertFalse($result['ok']);
 
-        // Today, but past time
-        // This is tricky to test deterministically without mocking local_date or time()
-        // but local_date uses date() which uses system time.
-        // We can skip "today" tests or just test the 1 hour buffer if possible.
+        // Test Same-Day Booking logic with mocked time
+        $mockDate = '2025-06-15';
+        $mockTime = '10:00'; // Current time is 10:00
+
+        // 1. Booking in the past (same day)
+        // 09:00 < 10:00 -> Fail
+        $result = validate_future_date($mockDate, '09:00', $mockDate, $mockTime);
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('ya pasó', $result['error']);
+
+        // 2. Booking exact same time
+        // 10:00 == 10:00 -> Fail (need 1h buffer)
+        $result = validate_future_date($mockDate, '10:00', $mockDate, $mockTime);
+        $this->assertFalse($result['ok']);
+
+        // 3. Booking 30 mins later
+        // 10:30 < 11:00 -> Fail
+        $result = validate_future_date($mockDate, '10:30', $mockDate, $mockTime);
+        $this->assertFalse($result['ok']);
+
+        // 4. Booking exactly 1 hour later
+        // 11:00 == 10:00 + 1h -> Fail (logic says <= 60 mins)
+        $result = validate_future_date($mockDate, '11:00', $mockDate, $mockTime);
+        $this->assertFalse($result['ok']);
+
+        // 5. Booking 1 hour and 1 min later
+        // 11:01 > 11:00 -> Pass
+        $result = validate_future_date($mockDate, '11:01', $mockDate, $mockTime);
+        $this->assertTrue($result['ok']);
+
+        // 6. Booking 2 hours later
+        // 12:00 > 11:00 -> Pass
+        $result = validate_future_date($mockDate, '12:00', $mockDate, $mockTime);
+        $this->assertTrue($result['ok']);
     }
 
     public function testValidateServiceExists(): void


### PR DESCRIPTION
Added unit tests for `validate_future_date` focusing on same-day booking validation logic. Refactored the function to support dependency injection of current date/time for deterministic testing.
Verified that existing tests pass and new tests cover edge cases like past time, exact current time, within 1 hour buffer, and after buffer.

---
*PR created automatically by Jules for task [1124733481653359267](https://jules.google.com/task/1124733481653359267) started by @erosero558558*