### PR TITLE
feat(admin): harden responsive sidebar navigation

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -20,6 +20,8 @@
 
 .admin-body.admin-sidebar-open {
     overflow: hidden;
+    overscroll-behavior: none;
+    touch-action: none;
 }
 
 .is-hidden {
@@ -182,6 +184,7 @@
     display: flex;
     flex-direction: column;
     z-index: 1000;
+    overscroll-behavior: contain;
 }
 
 .sidebar-header {
@@ -233,6 +236,8 @@
     flex: 1;
     padding: 16px 12px;
     overflow-y: auto;
+    scrollbar-gutter: stable;
+    scroll-padding-block: 12px;
 }
 
 .nav-item {
@@ -252,6 +257,25 @@
 .nav-item.active {
     background: rgba(255, 255, 255, 0.1);
     color: white;
+}
+
+.nav-item.active {
+    background: linear-gradient(
+        90deg,
+        rgba(76, 198, 255, 0.18),
+        rgba(255, 255, 255, 0.08)
+    );
+}
+
+.nav-item.active::after {
+    content: '';
+    position: absolute;
+    left: 8px;
+    top: 8px;
+    bottom: 8px;
+    width: 3px;
+    border-radius: 999px;
+    background: #4cc6ff;
 }
 
 .nav-item:focus-visible {
@@ -317,6 +341,7 @@
     position: fixed;
     inset: 0;
     background: rgba(10, 15, 26, 0.5);
+    backdrop-filter: blur(3px);
     border: 0;
     padding: 0;
     margin: 0;
@@ -1476,9 +1501,12 @@
    ======================================== */
 @media (max-width: 1024px) {
     .admin-sidebar {
+        width: min(88vw, 340px);
+        max-width: 340px;
         transform: translateX(-100%);
-        transition: transform 0.3s;
+        transition: transform 0.25s ease;
         box-shadow: 0 18px 48px rgba(0, 0, 0, 0.35);
+        padding-bottom: max(0px, env(safe-area-inset-bottom));
     }
 
     .admin-sidebar.is-open {
@@ -1487,6 +1515,15 @@
 
     .admin-sidebar-backdrop {
         display: block;
+    }
+
+    .sidebar-nav {
+        padding-inline: 10px;
+    }
+
+    .nav-item {
+        min-height: 48px;
+        border-radius: 14px;
     }
 
     .sidebar-close-btn,
@@ -1500,6 +1537,10 @@
 
     .admin-header {
         padding: 14px 18px;
+    }
+
+    .admin-header h2 {
+        font-size: 1.35rem;
     }
 
     .header-actions {

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
         <link rel="icon" href="/favicon.ico" sizes="any" />
         <link rel="stylesheet" href="styles.min.css" />
         <link rel="stylesheet" href="admin.min.css" />
-        <link rel="stylesheet" href="admin.css?v=admin-20260225-adminux2" />
+        <link rel="stylesheet" href="admin.css?v=admin-20260225-adminux3" />
         <link
             href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"
             rel="stylesheet"
@@ -82,6 +82,7 @@
                 class="admin-sidebar"
                 id="adminSidebar"
                 aria-label="Navegacion principal de administracion"
+                tabindex="-1"
             >
                 <div class="sidebar-header">
                     <div class="sidebar-brand">
@@ -655,6 +656,6 @@
         ></div>
 
         <!-- utils.js is now bundled/imported by admin.js -->
-        <script src="admin.js?v=admin-20260225-adminux2" type="module"></script>
+        <script src="admin.js?v=admin-20260225-adminux3" type="module"></script>
     </body>
 </html>

--- a/admin.js
+++ b/admin.js
@@ -393,7 +393,7 @@ function R(e) {
     const a = t.replace(/_/g, ' ').trim();
     return '' === a ? n.unknown : a.charAt(0).toUpperCase() + a.slice(1);
 }
-function x(e) {
+function H(e) {
     const t = String(e || '')
             .trim()
             .toLowerCase(),
@@ -408,7 +408,7 @@ function x(e) {
     const a = t.replace(/_/g, ' ').trim();
     return '' === a ? n.unknown : a.charAt(0).toUpperCase() + a.slice(1);
 }
-function H(e) {
+function x(e) {
     const t = String(e || '')
             .trim()
             .toLowerCase(),
@@ -622,13 +622,13 @@ function O() {
                 F(
                     'funnelSourceList',
                     e.eventSourceBreakdown,
-                    x,
+                    H,
                     'Sin datos de origen'
                 ),
                 F(
                     'funnelAbandonReasonList',
                     e.checkoutAbandonByReason,
-                    H,
+                    x,
                     'Sin datos de motivo'
                 ),
                 F(
@@ -1120,25 +1120,35 @@ async function he() {
         throw new Error('Disponibilidad en solo lectura (Google Calendar).');
     await h('availability', { method: 'POST', body: { availability: a } });
 }
-function ye() {
+const ye = [
+    'a[href]',
+    'button:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(',');
+function ve() {
     return Array.from(document.querySelectorAll('.nav-item[data-section]'));
 }
-function ve() {
-    const e = window.location.hash.replace(/^#/, '').trim();
-    return new Set(ye().map((e) => e.dataset.section)).has(e) ? e : 'dashboard';
-}
 function we() {
+    const e = window.location.hash.replace(/^#/, '').trim();
+    return new Set(ve().map((e) => e.dataset.section)).has(e) ? e : 'dashboard';
+}
+function Se() {
     return (
         document.querySelector('.nav-item.active')?.dataset.section ||
-        ve() ||
+        we() ||
         'dashboard'
     );
 }
-function Se() {
+function ke() {
     return window.innerWidth <= 1024;
 }
-function ke(e) {
-    ye().forEach((t) => {
+function Ee() {
+    return Boolean(
+        document.getElementById('adminSidebar')?.classList.contains('is-open')
+    );
+}
+function Ce(e) {
+    ve().forEach((t) => {
         const n = t.dataset.section === e;
         (t.classList.toggle('active', n),
             n
@@ -1146,31 +1156,67 @@ function ke(e) {
                 : t.removeAttribute('aria-current'));
     });
 }
-function Ee() {
+function Be() {
     return {
         sidebar: document.getElementById('adminSidebar'),
         backdrop: document.getElementById('adminSidebarBackdrop'),
         toggleBtn: document.getElementById('adminMenuToggle'),
     };
 }
-function Ce(e) {
-    const { sidebar: t, backdrop: n, toggleBtn: a } = Ee();
+function Le() {
+    const e = document.getElementById('adminSidebar');
+    return e
+        ? Array.from(e.querySelectorAll(ye)).filter(
+              (e) =>
+                  e instanceof HTMLElement &&
+                  !e.hasAttribute('disabled') &&
+                  !e.hasAttribute('aria-hidden')
+          )
+        : [];
+}
+function $e(e) {
+    const t = document.getElementById('adminSidebar'),
+        n = document.getElementById('adminMainContent'),
+        a = ke(),
+        o = Boolean(a && e);
+    (t && t.setAttribute('aria-hidden', String(!o && a)),
+        n &&
+            (o
+                ? n.setAttribute('aria-hidden', 'true')
+                : n.removeAttribute('aria-hidden')));
+}
+function Ie(e) {
+    const { sidebar: t, backdrop: n, toggleBtn: a } = Be();
     if (!t || !n || !a) return;
-    const o = Boolean(e && Se());
+    const o = Boolean(e && ke());
     (t.classList.toggle('is-open', o),
         n.classList.toggle('is-hidden', !o),
         n.setAttribute('aria-hidden', String(!o)),
         document.body.classList.toggle('admin-sidebar-open', o),
-        a.setAttribute('aria-expanded', String(o)));
+        a.setAttribute('aria-expanded', String(o)),
+        $e(o),
+        o &&
+            (function () {
+                const e = document.getElementById('adminSidebar');
+                if (!e) return;
+                const t = e.querySelector('.nav-item.active');
+                if (t instanceof HTMLElement)
+                    return (
+                        t.scrollIntoView({ block: 'nearest' }),
+                        void t.focus()
+                    );
+                const n = Le();
+                n[0] instanceof HTMLElement ? n[0].focus() : e.focus();
+            })());
 }
-function Be({ restoreFocus: e = !1 } = {}) {
-    const { toggleBtn: t } = Ee(),
+function Ae({ restoreFocus: e = !1 } = {}) {
+    const { toggleBtn: t } = Be(),
         n = document
             .getElementById('adminSidebar')
             ?.classList.contains('is-open');
-    (Ce(!1), e && n && t && t.focus());
+    (Ie(!1), e && n && t && t.focus());
 }
-async function Le(e, t = {}) {
+async function Te(e, t = {}) {
     const {
             refresh: n = !0,
             updateHash: a = !0,
@@ -1178,7 +1224,7 @@ async function Le(e, t = {}) {
             closeMobileNav: i = !0,
         } = t,
         r = e || 'dashboard';
-    if ((ke(r), i && Be(), n))
+    if ((Ce(r), i && Ae(), n))
         try {
             await M();
         } catch (e) {
@@ -1187,7 +1233,7 @@ async function Le(e, t = {}) {
                 'warning'
             );
         }
-    (await $e(r),
+    (await De(r),
         a &&
             (function (e) {
                 const t = `#${e}`;
@@ -1209,7 +1255,7 @@ async function Le(e, t = {}) {
                     }));
             })(r));
 }
-async function $e(e) {
+async function De(e) {
     const t = document.getElementById('pageTitle');
     (t &&
         (t.textContent =
@@ -1333,13 +1379,13 @@ async function $e(e) {
             })();
     }
 }
-async function Ie() {
+async function Ne() {
     const e = document.getElementById('loginScreen'),
         t = document.getElementById('adminDashboard');
     (e && e.classList.add('is-hidden'),
         t && t.classList.remove('is-hidden'),
-        ke(ve()),
-        Be(),
+        Ce(we()),
+        Ae(),
         await (async function () {
             const e = document.getElementById('currentDate');
             if (e) {
@@ -1359,8 +1405,8 @@ async function Ie() {
                     'warning'
                 );
             }
-            const t = we();
-            await $e(t);
+            const t = Se();
+            await De(t);
         })(),
         await (async function () {
             if (G) return;
@@ -1388,7 +1434,7 @@ async function Ie() {
             }
         })());
 }
-async function Ae(e) {
+async function Me(e) {
     e.preventDefault();
     const t = document.getElementById('group2FA');
     if (t && !t.classList.contains('is-hidden')) {
@@ -1399,7 +1445,7 @@ async function Ae(e) {
             })(e);
             (t.csrfToken && g(t.csrfToken),
                 w('Bienvenido al panel de administracion', 'success'),
-                await Ie());
+                await Ne());
         } catch {
             w('Codigo incorrecto o sesion expirada', 'error');
         }
@@ -1424,12 +1470,12 @@ async function Ae(e) {
         }
         (e.csrfToken && g(e.csrfToken),
             w('Bienvenido al panel de administracion', 'success'),
-            await Ie());
+            await Ne());
     } catch {
         w('Contrasena incorrecta', 'error');
     }
 }
-function Te() {
+function _e() {
     document.addEventListener('click', async (o) => {
         const i = o.target.closest('[data-action]');
         if (!i) return;
@@ -1842,13 +1888,13 @@ function Te() {
     r && r.addEventListener('change', z);
 }
 document.addEventListener('DOMContentLoaded', async () => {
-    Te();
+    _e();
     const e = document.getElementById('loginForm');
-    (e && e.addEventListener('submit', Ae),
-        ye().forEach((e) => {
+    (e && e.addEventListener('submit', Me),
+        ve().forEach((e) => {
             e.addEventListener('click', async (t) => {
                 (t.preventDefault(),
-                    await Le(e.dataset.section || 'dashboard'));
+                    await Te(e.dataset.section || 'dashboard'));
             });
         }),
         document
@@ -1856,25 +1902,43 @@ document.addEventListener('DOMContentLoaded', async () => {
             ?.addEventListener('click', () => {
                 const e = document.getElementById('adminSidebar'),
                     t = e?.classList.contains('is-open');
-                Ce(!t);
+                Ie(!t);
             }),
         document
             .getElementById('adminMenuClose')
-            ?.addEventListener('click', () => Be({ restoreFocus: !0 })),
+            ?.addEventListener('click', () => Ae({ restoreFocus: !0 })),
         document
             .getElementById('adminSidebarBackdrop')
-            ?.addEventListener('click', () => Be({ restoreFocus: !0 })),
+            ?.addEventListener('click', () => Ae({ restoreFocus: !0 })),
         window.addEventListener('keydown', (e) => {
-            'Escape' === e.key && Be({ restoreFocus: !0 });
+            (!(function (e) {
+                if ('Tab' !== e.key) return;
+                if (!ke() || !Ee()) return;
+                const t = document.getElementById('adminSidebar');
+                if (!t) return;
+                const n = Le();
+                if (0 === n.length) return (e.preventDefault(), void t.focus());
+                const a = n[0],
+                    o = n[n.length - 1],
+                    i = document.activeElement;
+                i instanceof HTMLElement && t.contains(i)
+                    ? e.shiftKey && i === a
+                        ? (e.preventDefault(), o.focus())
+                        : e.shiftKey ||
+                          i !== o ||
+                          (e.preventDefault(), a.focus())
+                    : (e.preventDefault(), (e.shiftKey ? o : a).focus());
+            })(e),
+                'Escape' === e.key && Ae({ restoreFocus: !0 }));
         }),
         window.addEventListener('resize', () => {
-            Se() || Be();
+            (ke() || Ae(), $e(Ee()));
         }),
         window.addEventListener('hashchange', async () => {
             const e = document.getElementById('adminDashboard');
             e &&
                 !e.classList.contains('is-hidden') &&
-                (await Le(ve(), {
+                (await Te(we(), {
                     refresh: !1,
                     updateHash: !1,
                     focus: !1,
@@ -1917,7 +1981,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                         (await h('import', { method: 'POST', body: a }),
                             await M());
                         const o = document.querySelector('.nav-item.active');
-                        (await $e(o?.dataset.section || 'dashboard'),
+                        (await De(o?.dataset.section || 'dashboard'),
                             w(
                                 `Datos importados: ${a.appointments.length} citas`,
                                 'success'
@@ -1930,13 +1994,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         window.addEventListener('online', async () => {
             (w('Conexion restaurada. Actualizando datos...', 'success'),
                 await M(),
-                await $e(we()));
+                await De(Se()));
         }),
+        $e(!1),
         await (async function () {
             if (!navigator.onLine && D('appointments', null))
                 return (
                     w('Modo offline: mostrando datos locales', 'info'),
-                    void (await Ie())
+                    void (await Ne())
                 );
             (await (async function () {
                 try {
@@ -1948,11 +2013,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                     return (w('No se pudo verificar la sesion', 'warning'), !1);
                 }
             })())
-                ? await Ie()
+                ? await Ne()
                 : (function () {
                       const e = document.getElementById('loginScreen'),
                           t = document.getElementById('adminDashboard');
-                      (Be(),
+                      (Ae(),
                           e && e.classList.remove('is-hidden'),
                           t && t.classList.add('is-hidden'));
                   })();

--- a/src/apps/admin/index.js
+++ b/src/apps/admin/index.js
@@ -35,6 +35,11 @@ import {
 } from './modules/availability.js';
 
 const ADMIN_NAV_COMPACT_BREAKPOINT = 1024;
+const SIDEBAR_FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(',');
 
 function getNavItems() {
     return Array.from(document.querySelectorAll('.nav-item[data-section]'));
@@ -56,6 +61,12 @@ function getActiveSection() {
 
 function isCompactAdminViewport() {
     return window.innerWidth <= ADMIN_NAV_COMPACT_BREAKPOINT;
+}
+
+function isSidebarOpen() {
+    return Boolean(
+        document.getElementById('adminSidebar')?.classList.contains('is-open')
+    );
 }
 
 function setNavActive(section) {
@@ -88,6 +99,100 @@ function getSidebarShellElements() {
     };
 }
 
+function getSidebarFocusableElements() {
+    const sidebar = document.getElementById('adminSidebar');
+    if (!sidebar) return [];
+
+    return Array.from(
+        sidebar.querySelectorAll(SIDEBAR_FOCUSABLE_SELECTOR)
+    ).filter(
+        (element) =>
+            element instanceof HTMLElement &&
+            !element.hasAttribute('disabled') &&
+            !element.hasAttribute('aria-hidden')
+    );
+}
+
+function syncSidebarOverlayA11yState(isOpen) {
+    const sidebar = document.getElementById('adminSidebar');
+    const mainContent = document.getElementById('adminMainContent');
+    const compactViewport = isCompactAdminViewport();
+    const overlayOpen = Boolean(compactViewport && isOpen);
+
+    if (sidebar) {
+        sidebar.setAttribute(
+            'aria-hidden',
+            String(!overlayOpen && compactViewport)
+        );
+    }
+
+    if (mainContent) {
+        if (overlayOpen) {
+            mainContent.setAttribute('aria-hidden', 'true');
+        } else {
+            mainContent.removeAttribute('aria-hidden');
+        }
+    }
+}
+
+function focusSidebarPrimaryTarget() {
+    const sidebar = document.getElementById('adminSidebar');
+    if (!sidebar) return;
+
+    const activeNavItem = sidebar.querySelector('.nav-item.active');
+    if (activeNavItem instanceof HTMLElement) {
+        activeNavItem.scrollIntoView({ block: 'nearest' });
+        activeNavItem.focus();
+        return;
+    }
+
+    const focusableElements = getSidebarFocusableElements();
+    if (focusableElements[0] instanceof HTMLElement) {
+        focusableElements[0].focus();
+        return;
+    }
+
+    sidebar.focus();
+}
+
+function trapSidebarFocus(event) {
+    if (event.key !== 'Tab') return;
+    if (!isCompactAdminViewport() || !isSidebarOpen()) return;
+
+    const sidebar = document.getElementById('adminSidebar');
+    if (!sidebar) return;
+
+    const focusableElements = getSidebarFocusableElements();
+    if (focusableElements.length === 0) {
+        event.preventDefault();
+        sidebar.focus();
+        return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+    const activeElement = document.activeElement;
+    const isFocusInsideSidebar =
+        activeElement instanceof HTMLElement && sidebar.contains(activeElement);
+
+    if (!isFocusInsideSidebar) {
+        event.preventDefault();
+        (event.shiftKey ? lastElement : firstElement).focus();
+        return;
+    }
+
+    if (event.shiftKey && activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+        return;
+    }
+
+    if (!event.shiftKey && activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+    }
+}
+
 function setSidebarOpen(isOpen) {
     const { sidebar, backdrop, toggleBtn } = getSidebarShellElements();
     if (!sidebar || !backdrop || !toggleBtn) return;
@@ -98,6 +203,11 @@ function setSidebarOpen(isOpen) {
     backdrop.setAttribute('aria-hidden', String(!shouldOpen));
     document.body.classList.toggle('admin-sidebar-open', shouldOpen);
     toggleBtn.setAttribute('aria-expanded', String(shouldOpen));
+    syncSidebarOverlayA11yState(shouldOpen);
+
+    if (shouldOpen) {
+        focusSidebarPrimaryTarget();
+    }
 }
 
 function closeSidebar({ restoreFocus = false } = {}) {
@@ -547,6 +657,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         ?.addEventListener('click', () => closeSidebar({ restoreFocus: true }));
 
     window.addEventListener('keydown', (event) => {
+        trapSidebarFocus(event);
+
         if (event.key !== 'Escape') return;
         closeSidebar({ restoreFocus: true });
     });
@@ -554,6 +666,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (!isCompactAdminViewport()) {
             closeSidebar();
         }
+        syncSidebarOverlayA11yState(isSidebarOpen());
     });
     window.addEventListener('hashchange', async () => {
         const dashboard = document.getElementById('adminDashboard');
@@ -579,5 +692,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         await renderSection(getActiveSection());
     });
 
+    syncSidebarOverlayA11yState(false);
     await checkAuthAndBoot();
 });

--- a/tests/admin-navigation-responsive.spec.js
+++ b/tests/admin-navigation-responsive.spec.js
@@ -1,0 +1,176 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test.use({
+    serviceWorkers: 'block',
+    viewport: { width: 900, height: 900 },
+});
+
+function jsonResponse(route, payload, status = 200) {
+    return route.fulfill({
+        status,
+        contentType: 'application/json; charset=utf-8',
+        body: JSON.stringify(payload),
+    });
+}
+
+function buildDataPayload() {
+    return {
+        ok: true,
+        data: {
+            appointments: [],
+            callbacks: [],
+            reviews: [],
+            availability: {},
+            availabilityMeta: {
+                source: 'store',
+                mode: 'live',
+                timezone: 'America/Guayaquil',
+                calendarConfigured: true,
+                calendarReachable: true,
+                generatedAt: new Date().toISOString(),
+            },
+        },
+    };
+}
+
+function buildFunnelPayload() {
+    return {
+        ok: true,
+        data: {
+            summary: {
+                viewBooking: 0,
+                startCheckout: 0,
+                bookingConfirmed: 0,
+                checkoutAbandon: 0,
+                startRatePct: 0,
+                confirmedRatePct: 0,
+                abandonRatePct: 0,
+            },
+            checkoutAbandonByStep: [],
+            checkoutEntryBreakdown: [],
+            paymentMethodBreakdown: [],
+            bookingStepBreakdown: [],
+            sourceBreakdown: [],
+            abandonReasonBreakdown: [],
+            errorCodeBreakdown: [],
+        },
+    };
+}
+
+async function setupAdminApiMocks(page) {
+    await page.route(/\/admin-auth\.php(\?.*)?$/i, async (route) => {
+        const url = new URL(route.request().url());
+        const action = url.searchParams.get('action') || '';
+
+        if (action === 'status') {
+            return jsonResponse(route, {
+                ok: true,
+                authenticated: true,
+                csrfToken: 'csrf_test_token',
+            });
+        }
+
+        return jsonResponse(route, {
+            ok: true,
+            authenticated: true,
+            csrfToken: 'csrf_test_token',
+        });
+    });
+
+    await page.route(/\/api\.php(\?.*)?$/i, async (route) => {
+        const url = new URL(route.request().url());
+        const resource = url.searchParams.get('resource') || '';
+
+        if (resource === 'data') {
+            return jsonResponse(route, buildDataPayload());
+        }
+
+        if (resource === 'funnel-metrics') {
+            return jsonResponse(route, buildFunnelPayload());
+        }
+
+        if (resource === 'availability') {
+            return jsonResponse(route, {
+                ok: true,
+                data: {},
+                meta: buildDataPayload().data.availabilityMeta,
+            });
+        }
+
+        return jsonResponse(route, { ok: true, data: {} });
+    });
+}
+
+test.describe('Admin navigation responsive (tablet)', () => {
+    test('sidebar compacto mantiene trap de foco y cierra con Escape', async ({
+        page,
+    }) => {
+        await setupAdminApiMocks(page);
+        await page.goto('/admin.html');
+
+        await expect(page.locator('#adminDashboard')).toBeVisible();
+        await expect(page.locator('#adminMenuToggle')).toBeVisible();
+
+        await page.locator('#adminMenuToggle').click();
+
+        await expect(page.locator('#adminSidebar')).toHaveClass(/is-open/);
+        await expect(page.locator('#adminSidebarBackdrop')).not.toHaveClass(
+            /is-hidden/
+        );
+        await expect(page.locator('#adminMenuToggle')).toHaveAttribute(
+            'aria-expanded',
+            'true'
+        );
+        await expect(
+            page.locator('#adminSidebar .nav-item.active')
+        ).toBeFocused();
+
+        await page.keyboard.press('Shift+Tab');
+        await expect(page.locator('#adminMenuClose')).toBeFocused();
+
+        await page.keyboard.press('Shift+Tab');
+        await expect(page.locator('.logout-btn')).toBeFocused();
+
+        await page.keyboard.press('Tab');
+        await expect(page.locator('#adminMenuClose')).toBeFocused();
+
+        await page.keyboard.press('Escape');
+
+        await expect(page.locator('#adminSidebar')).not.toHaveClass(/is-open/);
+        await expect(page.locator('#adminSidebarBackdrop')).toHaveClass(
+            /is-hidden/
+        );
+        await expect(page.locator('#adminMenuToggle')).toHaveAttribute(
+            'aria-expanded',
+            'false'
+        );
+        await expect(page.locator('#adminMenuToggle')).toBeFocused();
+    });
+
+    test('navegar desde sidebar compacto actualiza hash y cierra overlay', async ({
+        page,
+    }) => {
+        await setupAdminApiMocks(page);
+        await page.goto('/admin.html');
+
+        await expect(page.locator('#adminDashboard')).toBeVisible();
+        await page.locator('#adminMenuToggle').click();
+        await expect(page.locator('#adminSidebar')).toHaveClass(/is-open/);
+
+        await page
+            .locator('#adminSidebar .nav-item[data-section="appointments"]')
+            .click();
+
+        await expect(page.locator('#appointments')).toHaveClass(/active/);
+        await expect(
+            page.locator('#adminSidebar .nav-item[data-section="appointments"]')
+        ).toHaveAttribute('aria-current', 'page');
+        await expect(page).toHaveURL(/#appointments$/);
+        await expect(page.locator('#adminSidebar')).not.toHaveClass(/is-open/);
+        await expect(page.locator('#adminMenuToggle')).toHaveAttribute(
+            'aria-expanded',
+            'false'
+        );
+    });
+});


### PR DESCRIPTION
## Summary\n- harden compact admin sidebar navigation with keyboard focus trap and focus restoration\n- improve tablet sidebar overlay/touch-target styling and visual active state\n- add Playwright responsive admin navigation tests (sidebar trap + hash navigation)\n\n## Validation\n- npm run build\n- npx playwright test tests/admin-navigation-responsive.spec.js tests/admin.spec.js tests/admin-availability-readonly.spec.js tests/funnel-retention-admin.spec.js