### PR TITLE
feat(frontend): restore theme toggle and add admin dark mode

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -18,6 +18,17 @@
     background: var(--color-bg-gray);
 }
 
+.admin-body.theme-transition,
+.admin-body.theme-transition *,
+.admin-body.theme-transition *::before,
+.admin-body.theme-transition *::after {
+    transition:
+        background-color 0.2s ease,
+        border-color 0.2s ease,
+        color 0.2s ease,
+        box-shadow 0.2s ease !important;
+}
+
 .admin-body.admin-sidebar-open {
     overflow: hidden;
     overscroll-behavior: none;
@@ -68,6 +79,12 @@
     max-width: 400px;
     text-align: center;
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.login-theme-bar {
+    display: flex;
+    justify-content: flex-end;
+    margin: -8px -8px 10px;
 }
 
 .login-logo {
@@ -163,6 +180,50 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
+}
+
+.admin-theme-switcher {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px;
+    border-radius: 12px;
+    border: 1px solid #dbe5f2;
+    background: #f8fbff;
+}
+
+.admin-theme-switcher-header {
+    margin-right: 2px;
+}
+
+.admin-theme-btn {
+    width: 34px;
+    height: 34px;
+    border: 0;
+    border-radius: 10px;
+    background: transparent;
+    color: #5a6f88;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: 0.2s ease;
+}
+
+.admin-theme-btn:hover {
+    background: rgba(15, 88, 186, 0.08);
+    color: #0f58ba;
+}
+
+.admin-theme-btn.is-active {
+    background: #ffffff;
+    color: #0f58ba;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.admin-theme-btn:focus-visible {
+    outline: 3px solid rgba(0, 113, 227, 0.24);
+    outline-offset: 1px;
 }
 
 /* ========================================
@@ -442,6 +503,259 @@
     color: #ad2d2d;
     background: #fff1f1;
     border-color: #f0c9c9;
+}
+
+/* ========================================
+   ADMIN THEME (DARK)
+   ======================================== */
+html[data-theme='dark'] {
+    color-scheme: dark;
+}
+
+html[data-theme='dark'] .admin-body {
+    background: #0f1724;
+    color: #e6edf7;
+}
+
+html[data-theme='dark'] .admin-skip-link {
+    background: #101a2a;
+    color: #9bc7ff;
+    border-color: #4c8dff;
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.45);
+}
+
+html[data-theme='dark'] .login-screen {
+    background: linear-gradient(135deg, #18223b 0%, #231d39 100%);
+}
+
+html[data-theme='dark'] .login-box,
+html[data-theme='dark'] .admin-header,
+html[data-theme='dark'] .stat-card,
+html[data-theme='dark'] .dashboard-card,
+html[data-theme='dark'] .section-toolbar,
+html[data-theme='dark'] .table-container,
+html[data-theme='dark'] .reviews-stats,
+html[data-theme='dark'] .review-card-admin,
+html[data-theme='dark'] .availability-calendar,
+html[data-theme='dark'] .time-slots-config,
+html[data-theme='dark'] .toast {
+    background: #121c2d;
+    color: #e6edf7;
+    border-color: #26364d;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.22);
+}
+
+html[data-theme='dark'] .login-hint,
+html[data-theme='dark'] .current-date,
+html[data-theme='dark'] .stat-label,
+html[data-theme='dark'] .muted-label,
+html[data-theme='dark'] .funnel-chip-label,
+html[data-theme='dark'] .funnel-row-label,
+html[data-theme='dark'] .empty-message,
+html[data-theme='dark'] .toolbar-state-row,
+html[data-theme='dark'] .search-box i,
+html[data-theme='dark'] .calendar-day-header,
+html[data-theme='dark'] .selected-date,
+html[data-theme='dark'] .availability-helper,
+html[data-theme='dark'] .toast-message,
+html[data-theme='dark'] .toast-close,
+html[data-theme='dark'] .callback-time {
+    color: #9fb0c7;
+}
+
+html[data-theme='dark'] .login-logo h1,
+html[data-theme='dark'] .admin-header h2,
+html[data-theme='dark'] .dashboard-card h3,
+html[data-theme='dark'] .availability-calendar h3,
+html[data-theme='dark'] .time-slots-config h3,
+html[data-theme='dark'] .calendar-header span,
+html[data-theme='dark'] .big-rating,
+html[data-theme='dark'] .table-empty-state strong,
+html[data-theme='dark'] .card-empty-state strong,
+html[data-theme='dark'] .toolbar-state-label,
+html[data-theme='dark'] .availability-summary-chip strong,
+html[data-theme='dark'] .slot-presets-label,
+html[data-theme='dark'] .toast-title {
+    color: #edf4ff;
+}
+
+html[data-theme='dark'] .admin-theme-switcher {
+    background: #0f1724;
+    border-color: #2a3a52;
+}
+
+html[data-theme='dark'] .admin-theme-btn {
+    color: #9fb0c7;
+}
+
+html[data-theme='dark'] .admin-theme-btn:hover {
+    background: rgba(95, 168, 255, 0.12);
+    color: #b8d7ff;
+}
+
+html[data-theme='dark'] .admin-theme-btn.is-active {
+    background: #1b2940;
+    color: #8fc8ff;
+    box-shadow: inset 0 0 0 1px rgba(110, 160, 230, 0.14);
+}
+
+html[data-theme='dark'] .sidebar-brand span,
+html[data-theme='dark'] .nav-item,
+html[data-theme='dark'] .logout-btn,
+html[data-theme='dark'] .sidebar-close-btn {
+    color: rgba(235, 243, 255, 0.86);
+}
+
+html[data-theme='dark'] .admin-sidebar-backdrop {
+    background: rgba(2, 6, 13, 0.65);
+}
+
+html[data-theme='dark'] .status-pill-muted {
+    color: #b1c5dd;
+    background: #162334;
+    border-color: #2c4058;
+}
+
+html[data-theme='dark'] .funnel-chip,
+html[data-theme='dark'] .funnel-row,
+html[data-theme='dark'] .upcoming-item,
+html[data-theme='dark'] .toolbar-state-empty,
+html[data-theme='dark'] .toolbar-state-value,
+html[data-theme='dark'] .toolbar-chip,
+html[data-theme='dark'] .calendar-legend-chip,
+html[data-theme='dark'] .slot-count-badge,
+html[data-theme='dark'] .availability-day-actions,
+html[data-theme='dark'] .availability-summary-chip,
+html[data-theme='dark'] .slot-presets,
+html[data-theme='dark'] .time-slot-item,
+html[data-theme='dark'] .slot-readonly-tag,
+html[data-theme='dark'] .time-slots-list > .empty-message,
+html[data-theme='dark'] .callback-preference {
+    background: #162334;
+    border-color: #2a3b52;
+    color: #c9d7e7;
+}
+
+html[data-theme='dark'] .toolbar-chip.is-accent,
+html[data-theme='dark'] .availability-day-actions-status .toolbar-chip.is-info,
+html[data-theme='dark'] .availability-summary-chip.is-editable {
+    background: #102744;
+    border-color: #284d7a;
+    color: #8fc8ff;
+}
+
+html[data-theme='dark'] .toolbar-chip.is-warning {
+    background: #342b14;
+    border-color: #6a5525;
+    color: #ffd287;
+}
+
+html[data-theme='dark'] .availability-day-actions-status .toolbar-chip.is-muted,
+html[data-theme='dark'] .availability-summary-chip.is-readonly {
+    background: #172130;
+    border-color: #2d3a4d;
+    color: #b1c2d6;
+}
+
+html[data-theme='dark'] .availability-day-actions-status .toolbar-chip.is-danger,
+html[data-theme='dark'] .btn-secondary.danger-soft {
+    background: #311a21;
+    border-color: #64323d;
+    color: #ffb9c4;
+}
+
+html[data-theme='dark'] .btn-secondary.danger-soft:hover {
+    background: #3a2028;
+    border-color: #7a3c49;
+}
+
+html[data-theme='dark'] .filter-group select,
+html[data-theme='dark'] .search-box input,
+html[data-theme='dark'] .add-slot-form input {
+    background: #0f1724;
+    border-color: #2a3b52;
+    color: #ecf3ff;
+}
+
+html[data-theme='dark'] .filter-group select option {
+    background: #101a2a;
+    color: #ecf3ff;
+}
+
+html[data-theme='dark'] .data-table th {
+    background: #172437;
+    color: #9db1ca;
+    border-bottom-color: #273952;
+}
+
+html[data-theme='dark'] .data-table td {
+    color: #dbe6f4;
+    border-bottom-color: #23354d;
+}
+
+html[data-theme='dark'] .data-table tr:hover {
+    background: rgba(95, 168, 255, 0.06);
+}
+
+html[data-theme='dark'] #appointmentsTable .appointment-row {
+    background: #121c2d;
+    border-color: #26364d;
+}
+
+html[data-theme='dark'] #appointmentsTable .appointment-row:hover {
+    background: #121c2d;
+}
+
+html[data-theme='dark'] #appointmentsTable .appointment-row td::before {
+    color: #93a8c2;
+}
+
+html[data-theme='dark'] .calendar-header .btn-icon,
+html[data-theme='dark'] .time-slot-item .slot-actions .btn-icon {
+    background: #162334;
+    border-color: #2a3b52;
+    color: #d8e3f1;
+}
+
+html[data-theme='dark'] .calendar-day:hover {
+    background: #1a2739;
+}
+
+html[data-theme='dark'] .calendar-day.other-month {
+    color: #546780;
+}
+
+html[data-theme='dark'] .calendar-day.today {
+    border-color: #6fb1ff;
+}
+
+html[data-theme='dark'] .calendar-day.selected {
+    background: #2473eb;
+}
+
+html[data-theme='dark'] .slot-preset-btn {
+    background: #101a2a;
+    border-color: #2b3f58;
+    color: #d5e2f3;
+}
+
+html[data-theme='dark'] .slot-preset-btn:hover {
+    background: #15253a;
+    border-color: #40658e;
+}
+
+html[data-theme='dark'] .add-slot-form {
+    border-top-color: #273952;
+}
+
+html[data-theme='dark'] .table-empty-state,
+html[data-theme='dark'] .card-empty-state {
+    color: #9fb0c7;
+}
+
+html[data-theme='dark'] .table-empty-state i,
+html[data-theme='dark'] .card-empty-state i {
+    color: #6f88a7;
 }
 
 /* Admin Sections */

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
         <link rel="icon" href="/favicon.ico" sizes="any" />
         <link rel="stylesheet" href="styles.min.css" />
         <link rel="stylesheet" href="admin.min.css" />
-        <link rel="stylesheet" href="admin.css?v=admin-20260226-adminux6" />
+        <link rel="stylesheet" href="admin.css?v=admin-20260226-theme1" />
         <link
             href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"
             rel="stylesheet"
@@ -29,6 +29,47 @@
         <!-- Login Screen -->
         <div id="loginScreen" class="login-screen">
             <div class="login-box">
+                <div class="login-theme-bar">
+                    <div
+                        class="admin-theme-switcher"
+                        role="group"
+                        aria-label="Tema de color"
+                    >
+                        <button
+                            type="button"
+                            class="admin-theme-btn"
+                            data-action="set-admin-theme"
+                            data-theme-mode="light"
+                            aria-label="Modo claro"
+                            aria-pressed="false"
+                            title="Modo claro"
+                        >
+                            <i class="fas fa-sun"></i>
+                        </button>
+                        <button
+                            type="button"
+                            class="admin-theme-btn"
+                            data-action="set-admin-theme"
+                            data-theme-mode="dark"
+                            aria-label="Modo oscuro"
+                            aria-pressed="false"
+                            title="Modo oscuro"
+                        >
+                            <i class="fas fa-moon"></i>
+                        </button>
+                        <button
+                            type="button"
+                            class="admin-theme-btn"
+                            data-action="set-admin-theme"
+                            data-theme-mode="system"
+                            aria-label="Modo sistema"
+                            aria-pressed="true"
+                            title="Modo sistema"
+                        >
+                            <i class="fas fa-circle-half-stroke"></i>
+                        </button>
+                    </div>
+                </div>
                 <div class="login-logo">
                     <i class="fas fa-spa"></i>
                     <h1>Panel de Administración</h1>
@@ -180,6 +221,45 @@
                         <h2 id="pageTitle">Dashboard</h2>
                     </div>
                     <div class="header-actions">
+                        <div
+                            class="admin-theme-switcher admin-theme-switcher-header"
+                            role="group"
+                            aria-label="Tema de color"
+                        >
+                            <button
+                                type="button"
+                                class="admin-theme-btn"
+                                data-action="set-admin-theme"
+                                data-theme-mode="light"
+                                aria-label="Modo claro"
+                                aria-pressed="false"
+                                title="Modo claro"
+                            >
+                                <i class="fas fa-sun"></i>
+                            </button>
+                            <button
+                                type="button"
+                                class="admin-theme-btn"
+                                data-action="set-admin-theme"
+                                data-theme-mode="dark"
+                                aria-label="Modo oscuro"
+                                aria-pressed="false"
+                                title="Modo oscuro"
+                            >
+                                <i class="fas fa-moon"></i>
+                            </button>
+                            <button
+                                type="button"
+                                class="admin-theme-btn"
+                                data-action="set-admin-theme"
+                                data-theme-mode="system"
+                                aria-label="Modo sistema"
+                                aria-pressed="true"
+                                title="Modo sistema"
+                            >
+                                <i class="fas fa-circle-half-stroke"></i>
+                            </button>
+                        </div>
                         <span class="current-date" id="currentDate"></span>
                         <span
                             id="pushStatusIndicator"
@@ -880,6 +960,6 @@
         ></div>
 
         <!-- utils.js is now bundled/imported by admin.js -->
-        <script src="admin.js?v=admin-20260226-adminux6" type="module"></script>
+        <script src="admin.js?v=admin-20260226-theme1" type="module"></script>
     </body>
 </html>

--- a/admin.js
+++ b/admin.js
@@ -123,7 +123,7 @@ function B(e) {
         }[e] || e
     );
 }
-function C(e) {
+function L(e) {
     return (
         {
             rosero: 'Dr. Rosero',
@@ -132,7 +132,7 @@ function C(e) {
         }[e] || e
     );
 }
-function $(e) {
+function C(e) {
     return (
         {
             confirmed: 'Confirmada',
@@ -144,7 +144,7 @@ function $(e) {
         }[e] || e
     );
 }
-function L(e) {
+function $(e) {
     return (
         {
             card: 'Tarjeta',
@@ -814,13 +814,72 @@ async function ee() {
         (t && (t.className = n), (e.disabled = !1));
     }
 }
-const te = 'admin-appointments-sort',
-    ne = 'admin-appointments-density',
-    ae = 'datetime_desc',
-    oe = 'comfortable',
-    ie = new Set(['datetime_desc', 'datetime_asc', 'triage', 'patient_az']),
-    re = new Set(['comfortable', 'compact']);
+const te = 'themeMode',
+    ne = new Set(['light', 'dark', 'system']);
+let ae = 'system',
+    oe = null,
+    ie = !1,
+    re = null;
 function se() {
+    return (
+        oe ||
+            'function' != typeof window.matchMedia ||
+            (oe = window.matchMedia('(prefers-color-scheme: dark)')),
+        oe
+    );
+}
+function ce(e) {
+    return ne.has(String(e || '').trim());
+}
+function le(e) {
+    const t = document.documentElement;
+    if (!t) return;
+    const n = (function (e) {
+        return 'system' !== e ? e : se()?.matches ? 'dark' : 'light';
+    })(e);
+    (t.setAttribute('data-theme-mode', e), t.setAttribute('data-theme', n));
+}
+function de() {
+    document
+        .querySelectorAll('.admin-theme-btn[data-theme-mode]')
+        .forEach((e) => {
+            const t = e.dataset.themeMode === ae;
+            (e.classList.toggle('is-active', t),
+                e.setAttribute('aria-pressed', String(t)));
+        });
+}
+function ue(e, { persist: t = !1, animate: n = !1 } = {}) {
+    const a = ce(e) ? e : 'system';
+    ((ae = a),
+        t &&
+            (function (e) {
+                try {
+                    localStorage.setItem(te, e);
+                } catch (e) {}
+            })(a),
+        n &&
+            document.body &&
+            (window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ||
+                (re && clearTimeout(re),
+                document.body.classList.remove('theme-transition'),
+                document.body.offsetWidth,
+                document.body.classList.add('theme-transition'),
+                (re = setTimeout(() => {
+                    document.body?.classList.remove('theme-transition');
+                }, 220)))),
+        le(a),
+        de());
+}
+function me() {
+    'system' === ae && (le('system'), de());
+}
+const pe = 'admin-appointments-sort',
+    fe = 'admin-appointments-density',
+    ge = 'datetime_desc',
+    ye = 'comfortable',
+    he = new Set(['datetime_desc', 'datetime_asc', 'triage', 'patient_az']),
+    be = new Set(['comfortable', 'compact']);
+function ve() {
     return {
         filterSelect: document.getElementById('appointmentFilter'),
         sortSelect: document.getElementById('appointmentSort'),
@@ -835,26 +894,26 @@ function se() {
         ),
     };
 }
-function ce(e) {
+function we(e) {
     const t = String(e || '').trim();
-    return ie.has(t) ? t : ae;
+    return he.has(t) ? t : ge;
 }
-function le(e) {
+function Se(e) {
     const t = String(e || '').trim();
-    return re.has(t) ? t : oe;
+    return be.has(t) ? t : ye;
 }
-function de(e, t) {
+function Ee(e, t) {
     try {
         localStorage.setItem(e, JSON.stringify(t));
     } catch (e) {}
 }
-function ue(e) {
-    const t = le(e),
-        { appointmentsSection: n } = se();
+function ke(e) {
+    const t = Se(e),
+        { appointmentsSection: n } = ve();
     (n?.classList.toggle('appointments-density-compact', 'compact' === t),
         (function (e) {
-            const t = le(e),
-                { densityButtons: n } = se();
+            const t = Se(e),
+                { densityButtons: n } = ve();
             n.forEach((e) => {
                 const n = e.dataset.density === t;
                 (e.classList.toggle('is-active', n),
@@ -862,7 +921,7 @@ function ue(e) {
             });
         })(t));
 }
-function me(e) {
+function Be(e) {
     const t = String(e?.paymentStatus || ''),
         n = String(e?.status || 'confirmed'),
         a = new Date().toISOString().split('T')[0],
@@ -883,12 +942,12 @@ function me(e) {
                     ? 6
                     : 7;
 }
-function pe() {
+function Le() {
     const t = (function () {
-            const { filterSelect: e, sortSelect: t, searchInput: n } = se();
+            const { filterSelect: e, sortSelect: t, searchInput: n } = ve();
             return {
                 filter: String(e?.value || 'all'),
-                sort: ce(t?.value || ae),
+                sort: we(t?.value || ge),
                 search: String(n?.value || '').trim(),
             };
         })(),
@@ -998,7 +1057,7 @@ function pe() {
             return void (a.innerHTML =
                 '\n            <tr class="table-empty-row">\n                <td colspan="8">\n                    <div class="table-empty-state">\n                        <i class="fas fa-calendar-check" aria-hidden="true"></i>\n                        <strong>No hay citas registradas</strong>\n                        <p>Cuando ingresen reservas nuevas apareceran aqui con acciones rapidas.</p>\n                    </div>\n                </td>\n            </tr>\n        ');
         const o = (function (e, t) {
-            const n = ce(t),
+            const n = we(t),
                 a = Array.isArray(e) ? [...e] : [],
                 o = (e, t) => {
                     const n = `${String(e?.date || '')} ${String(e?.time || '')}`,
@@ -1014,12 +1073,12 @@ function pe() {
                 }
                 if ('datetime_asc' === n) return o(e, t);
                 if ('triage' === n) {
-                    const n = me(e) - me(t);
+                    const n = Be(e) - Be(t);
                     return 0 !== n ? n : o(e, t);
                 }
                 return -o(e, t);
             });
-        })(t, n?.sort || ae);
+        })(t, n?.sort || ge);
         a.innerHTML = o
             .map((e) => {
                 const t = String(e.status || 'confirmed'),
@@ -1034,7 +1093,7 @@ function pe() {
                         .filter(Boolean)
                         .join(' '),
                     i = e.doctorAssigned
-                        ? `<br><small>Asignado: ${v(C(e.doctorAssigned))}</small>`
+                        ? `<br><small>Asignado: ${v(L(e.doctorAssigned))}</small>`
                         : '',
                     r = e.transferReference
                         ? `<br><small>Ref: ${v(e.transferReference)}</small>`
@@ -1051,7 +1110,7 @@ function pe() {
                         ? `<br><a class="appointment-proof-link" href="${v(s)}" target="_blank" rel="noopener noreferrer"><i class="fas fa-file-arrow-up" aria-hidden="true"></i> Ver comprobante</a>`
                         : '',
                     l = String(e.phone || '').replace(/\D/g, '');
-                return `\n        <tr class="${o}">\n            <td data-label="Paciente" class="appointment-cell-main">\n                <strong>${v(e.name)}</strong><br>\n                <small>${v(e.email)}</small>\n                <div class="appointment-inline-meta">\n                    <span class="toolbar-chip">${v(String(e.phone || 'Sin telefono'))}</span>\n                </div>\n            </td>\n            <td data-label="Servicio">${v(B(e.service))}</td>\n            <td data-label="Doctor">${v(C(e.doctor))}${i}</td>\n            <td data-label="Fecha">${v(
+                return `\n        <tr class="${o}">\n            <td data-label="Paciente" class="appointment-cell-main">\n                <strong>${v(e.name)}</strong><br>\n                <small>${v(e.email)}</small>\n                <div class="appointment-inline-meta">\n                    <span class="toolbar-chip">${v(String(e.phone || 'Sin telefono'))}</span>\n                </div>\n            </td>\n            <td data-label="Servicio">${v(B(e.service))}</td>\n            <td data-label="Doctor">${v(L(e.doctor))}${i}</td>\n            <td data-label="Fecha">${v(
                     (function (e) {
                         const t = new Date(e);
                         return Number.isNaN(t.getTime())
@@ -1062,25 +1121,25 @@ function pe() {
                                   year: 'numeric',
                               });
                     })(e.date)
-                )}</td>\n            <td data-label="Hora">${v(e.time)}</td>\n            <td data-label="Pago" class="appointment-payment-cell">\n                <strong>${v(e.price || '$0.00')}</strong>\n                <small>${v(L(e.paymentMethod))} - ${v(A(n))}</small>\n                ${r}\n                ${c}\n            </td>\n            <td data-label="Estado">\n                <span class="status-badge status-${v(t)}">\n                    ${v($(t))}\n                </span>\n            </td>\n            <td data-label="Acciones">\n                <div class="table-actions">\n                    ${a ? `\n                    <button type="button" class="btn-icon success" data-action="approve-transfer" data-id="${Number(e.id) || 0}" title="Aprobar transferencia">\n                        <i class="fas fa-check"></i>\n                    </button>\n                    <button type="button" class="btn-icon danger" data-action="reject-transfer" data-id="${Number(e.id) || 0}" title="Rechazar transferencia">\n                        <i class="fas fa-ban"></i>\n                    </button>\n                    ` : ''}\n                    <a href="tel:${v(e.phone)}" class="btn-icon" title="Llamar" aria-label="Llamar a ${v(e.name)}">\n                        <i class="fas fa-phone"></i>\n                    </a>\n                    <a href="https://wa.me/${v(l)}" target="_blank" rel="noopener noreferrer" class="btn-icon" title="WhatsApp" aria-label="Abrir WhatsApp de ${v(e.name)}">\n                        <i class="fab fa-whatsapp"></i>\n                    </a>\n                    <button type="button" class="btn-icon danger" data-action="cancel-appointment" data-id="${Number(e.id) || 0}" title="Cancelar">\n                        <i class="fas fa-times"></i>\n                    </button>\n                    ${'cancelled' !== t && 'completed' !== t && 'no_show' !== t ? `\n                    <button type="button" class="btn-icon warning" data-action="mark-no-show" data-id="${Number(e.id) || 0}" title="Marcar no asistio">\n                        <i class="fas fa-user-slash"></i>\n                    </button>\n                    ` : ''}\n                </div>\n            </td>\n        </tr>\n    `;
+                )}</td>\n            <td data-label="Hora">${v(e.time)}</td>\n            <td data-label="Pago" class="appointment-payment-cell">\n                <strong>${v(e.price || '$0.00')}</strong>\n                <small>${v($(e.paymentMethod))} - ${v(A(n))}</small>\n                ${r}\n                ${c}\n            </td>\n            <td data-label="Estado">\n                <span class="status-badge status-${v(t)}">\n                    ${v(C(t))}\n                </span>\n            </td>\n            <td data-label="Acciones">\n                <div class="table-actions">\n                    ${a ? `\n                    <button type="button" class="btn-icon success" data-action="approve-transfer" data-id="${Number(e.id) || 0}" title="Aprobar transferencia">\n                        <i class="fas fa-check"></i>\n                    </button>\n                    <button type="button" class="btn-icon danger" data-action="reject-transfer" data-id="${Number(e.id) || 0}" title="Rechazar transferencia">\n                        <i class="fas fa-ban"></i>\n                    </button>\n                    ` : ''}\n                    <a href="tel:${v(e.phone)}" class="btn-icon" title="Llamar" aria-label="Llamar a ${v(e.name)}">\n                        <i class="fas fa-phone"></i>\n                    </a>\n                    <a href="https://wa.me/${v(l)}" target="_blank" rel="noopener noreferrer" class="btn-icon" title="WhatsApp" aria-label="Abrir WhatsApp de ${v(e.name)}">\n                        <i class="fab fa-whatsapp"></i>\n                    </a>\n                    <button type="button" class="btn-icon danger" data-action="cancel-appointment" data-id="${Number(e.id) || 0}" title="Cancelar">\n                        <i class="fas fa-times"></i>\n                    </button>\n                    ${'cancelled' !== t && 'completed' !== t && 'no_show' !== t ? `\n                    <button type="button" class="btn-icon warning" data-action="mark-no-show" data-id="${Number(e.id) || 0}" title="Marcar no asistio">\n                        <i class="fas fa-user-slash"></i>\n                    </button>\n                    ` : ''}\n                </div>\n            </td>\n        </tr>\n    `;
             })
             .join('');
     })(n, { sort: t.sort }),
         (function (e, t) {
-            const { stateRow: n, clearBtn: a } = se();
+            const { stateRow: n, clearBtn: a } = ve();
             if (!n) return;
             const o = String(e?.filter || 'all'),
-                i = ce(e?.sort || ae),
+                i = we(e?.sort || ge),
                 r = String(e?.search || '').trim(),
                 s = (function () {
-                    const { appointmentsSection: e } = se();
+                    const { appointmentsSection: e } = ve();
                     return e?.classList.contains('appointments-density-compact')
                         ? 'compact'
                         : 'comfortable';
                 })(),
                 c = 'all' !== o,
                 l = r.length > 0,
-                d = i !== ae || s !== oe;
+                d = i !== ge || s !== ye;
             if (
                 (a &&
                     (a.classList.toggle('is-hidden', !c && !l),
@@ -1114,7 +1173,7 @@ function pe() {
                                 triage: 'Triage operativo',
                                 patient_az: 'Paciente (A-Z)',
                             };
-                            return t[ce(e)] || t.datetime_desc;
+                            return t[we(e)] || t.datetime_desc;
                         })(i)
                     )}</span>`
                 ),
@@ -1125,40 +1184,40 @@ function pe() {
                                 comfortable: 'Comoda',
                                 compact: 'Compacta',
                             };
-                            return t[le(e)] || t.comfortable;
+                            return t[Se(e)] || t.comfortable;
                         })(s)
                     )}</span>`
                 ),
                 (n.innerHTML = m.join('')));
         })(t, n));
 }
-function fe() {
-    pe();
+function Ce() {
+    Le();
 }
-function ge(e) {
+function $e(e) {
     let t = String(e ?? '');
     return (/^[=+\-@]/.test(t) && (t = "'" + t), `"${t.replace(/"/g, '""')}"`);
 }
-let ye = null,
-    he = new Date(),
-    be = !1,
-    ve = null;
-const we = 'admin-availability-day-clipboard';
-function Se(e) {
+let Ae = null,
+    Ie = new Date(),
+    De = !1,
+    Te = null;
+const Ne = 'admin-availability-day-clipboard';
+function Me(e) {
     return `${e.getFullYear()}-${String(e.getMonth() + 1).padStart(2, '0')}-${String(e.getDate()).padStart(2, '0')}`;
 }
-function Ee(e) {
+function _e(e) {
     const t = String(e || '').trim(),
         n = t.match(/^(\d{4})-(\d{2})-(\d{2})$/);
     if (n) return new Date(Number(n[1]), Number(n[2]) - 1, Number(n[3]));
     const a = new Date(t);
     return Number.isNaN(a.getTime()) ? null : a;
 }
-function ke() {
-    ve ||
-        (ve = (function () {
+function Pe() {
+    Te ||
+        (Te = (function () {
             try {
-                const e = JSON.parse(localStorage.getItem(we) || 'null');
+                const e = JSON.parse(localStorage.getItem(Ne) || 'null');
                 if (!e || 'object' != typeof e) return null;
                 const t = String(e.sourceDate || '').trim(),
                     n = Array.isArray(e.slots)
@@ -1174,19 +1233,19 @@ function ke() {
             }
         })());
 }
-function Be() {
+function He() {
     try {
         if (
-            ve &&
-            'object' == typeof ve &&
-            Array.isArray(ve.slots) &&
-            ve.slots.length > 0
+            Te &&
+            'object' == typeof Te &&
+            Array.isArray(Te.slots) &&
+            Te.slots.length > 0
         )
-            return void localStorage.setItem(we, JSON.stringify(ve));
-        localStorage.removeItem(we);
+            return void localStorage.setItem(Ne, JSON.stringify(Te));
+        localStorage.removeItem(Ne);
     } catch (e) {}
 }
-function Ce(e) {
+function Re(e) {
     return Array.from(
         new Set(
             (Array.isArray(e) ? e : [])
@@ -1195,17 +1254,17 @@ function Ce(e) {
         )
     ).sort();
 }
-function $e(e, t) {
+function xe(e, t) {
     const n = String(e || '').trim(),
-        a = Ce(t);
-    if (!n || 0 === a.length) return ((ve = null), void Be());
-    ((ve = { sourceDate: n, slots: a, copiedAt: new Date().toISOString() }),
-        Be());
+        a = Re(t);
+    if (!n || 0 === a.length) return ((Te = null), void He());
+    ((Te = { sourceDate: n, slots: a, copiedAt: new Date().toISOString() }),
+        He());
 }
-function Le(e) {
+function je(e) {
     const t = String(e || '').trim();
     if (!t) return 'n/d';
-    const n = Ee(t);
+    const n = _e(t);
     return n
         ? n.toLocaleDateString('es-EC', {
               weekday: 'short',
@@ -1214,53 +1273,53 @@ function Le(e) {
           })
         : t;
 }
-function Ae() {
-    return ye ? Ce(a[ye] || []) : [];
+function Fe() {
+    return Ae ? Re(a[Ae] || []) : [];
 }
-function Ie(e, t) {
+function Oe(e, t) {
     const n = String(e || '').trim();
     if (!n) return;
-    const o = Ce(t);
+    const o = Re(t);
     0 !== o.length ? (a[n] = o) : delete a[n];
 }
-function De(e) {
-    const t = Ee(e);
-    t && (he = new Date(t.getFullYear(), t.getMonth(), 1));
+function qe(e) {
+    const t = _e(e);
+    t && (Ie = new Date(t.getFullYear(), t.getMonth(), 1));
 }
-function Te(e) {
+function Ue(e) {
     const t = String(e || '').trim();
     if (!t) return 'n/d';
     const n = new Date(t);
     return Number.isNaN(n.getTime()) ? 'n/d' : n.toLocaleString('es-EC');
 }
-function Ne(e) {
+function ze(e) {
     const t = document.getElementById('availabilityHelperText');
     t && (t.textContent = String(e || '').trim());
 }
-function Me(e) {
+function Ge(e) {
     const t = document.getElementById('timeSlotsCountBadge');
     if (!t) return;
     const n =
         Number.isFinite(Number(e)) && Number(e) > 0 ? Math.round(Number(e)) : 0;
     t.textContent = `${n} horario${1 === n ? '' : 's'}`;
 }
-function _e() {
+function We() {
     const e = document.getElementById('availabilitySelectionSummary');
     if (!e) return;
     const t =
             'google' === String(o.source || 'store')
                 ? 'Google Calendar'
                 : 'Local',
-        n = be ? 'Solo lectura' : 'Editable',
-        i = String(ye || '').trim(),
+        n = De ? 'Solo lectura' : 'Editable',
+        i = String(Ae || '').trim(),
         r = i ? (Array.isArray(a[i]) ? a[i].length : 0) : null;
     if (!i)
         return void (e.innerHTML = [
             `<span class="availability-summary-chip"><strong>Fuente:</strong> ${v(t)}</span>`,
-            `<span class="availability-summary-chip ${be ? 'is-readonly' : 'is-editable'}"><strong>Modo:</strong> ${v(n)}</span>`,
+            `<span class="availability-summary-chip ${De ? 'is-readonly' : 'is-editable'}"><strong>Modo:</strong> ${v(n)}</span>`,
             '<span class="toolbar-state-empty">Selecciona una fecha para ver el detalle del dia</span>',
         ].join(''));
-    const s = Ee(i),
+    const s = _e(i),
         c = s
             ? s.toLocaleDateString('es-EC', {
                   weekday: 'short',
@@ -1270,20 +1329,20 @@ function _e() {
             : i;
     e.innerHTML = [
         `<span class="availability-summary-chip"><strong>Fuente:</strong> ${v(t)}</span>`,
-        `<span class="availability-summary-chip ${be ? 'is-readonly' : 'is-editable'}"><strong>Modo:</strong> ${v(n)}</span>`,
+        `<span class="availability-summary-chip ${De ? 'is-readonly' : 'is-editable'}"><strong>Modo:</strong> ${v(n)}</span>`,
         `<span class="availability-summary-chip"><strong>Fecha:</strong> ${v(c)}</span>`,
         `<span class="availability-summary-chip"><strong>Slots:</strong> ${v(String(r ?? 0))}</span>`,
     ].join('');
 }
-function Pe() {
-    ke();
+function Je() {
+    Pe();
     const e = document.getElementById('availabilityDayActions'),
         t = document.getElementById('availabilityDayActionsStatus');
     if (!e || !t) return;
-    const n = Boolean(String(ye || '').trim()),
-        a = Ae(),
+    const n = Boolean(String(Ae || '').trim()),
+        a = Fe(),
         o = a.length > 0,
-        i = Ce(ve?.slots || []),
+        i = Re(Te?.slots || []),
         r = i.length > 0,
         s = e.querySelector('[data-action="copy-availability-day"]'),
         c = e.querySelector('[data-action="paste-availability-day"]'),
@@ -1291,9 +1350,9 @@ function Pe() {
         d = e.querySelector('[data-action="clear-availability-day"]');
     if (
         (s instanceof HTMLButtonElement && (s.disabled = !n || !o),
-        c instanceof HTMLButtonElement && (c.disabled = !n || !r || be),
-        l instanceof HTMLButtonElement && (l.disabled = !n || !o || be),
-        d instanceof HTMLButtonElement && (d.disabled = !n || !o || be),
+        c instanceof HTMLButtonElement && (c.disabled = !n || !r || De),
+        l instanceof HTMLButtonElement && (l.disabled = !n || !o || De),
+        d instanceof HTMLButtonElement && (d.disabled = !n || !o || De),
         e.classList.toggle('is-hidden', !n && !r),
         !n && !r)
     )
@@ -1302,25 +1361,25 @@ function Pe() {
     const u = [];
     (n &&
         (u.push(
-            `<span class="toolbar-chip is-info">Fecha activa: ${v(Le(ye))}</span>`
+            `<span class="toolbar-chip is-info">Fecha activa: ${v(je(Ae))}</span>`
         ),
         u.push(
             `<span class="toolbar-chip is-muted">Slots: ${v(String(a.length))}</span>`
         )),
         r
             ? u.push(
-                  `<span class="toolbar-chip">Portapapeles: ${v(String(i.length))} (${v(Le(ve?.sourceDate))})</span>`
+                  `<span class="toolbar-chip">Portapapeles: ${v(String(i.length))} (${v(je(Te?.sourceDate))})</span>`
               )
             : u.push(
                   '<span class="toolbar-chip is-muted">Portapapeles vacio</span>'
               ),
-        be &&
+        De &&
             u.push(
                 '<span class="toolbar-chip is-danger">Edicion bloqueada por Google Calendar</span>'
             ),
         (t.innerHTML = u.join('')));
 }
-function He() {
+function Ve() {
     const {
         statusEl: e,
         detailsEl: t,
@@ -1360,9 +1419,9 @@ function He() {
         c = !1 === o.calendarTokenHealthy ? 'no' : 'si',
         l = !1 === o.calendarConfigured ? 'no' : 'si',
         d = !1 === o.calendarReachable ? 'no' : 'si',
-        u = Te(o.generatedAt),
-        m = Te(o.calendarLastSuccessAt),
-        p = Te(o.calendarLastErrorAt),
+        u = Ue(o.generatedAt),
+        m = Ue(o.calendarLastSuccessAt),
+        p = Ue(o.calendarLastErrorAt),
         f = String(o.calendarLastErrorReason || '').trim();
     if ('google' === a) {
         const n = 'blocked' === i ? 'bloqueado' : 'live';
@@ -1376,13 +1435,13 @@ function He() {
                 (e += ` | Ultimo error: <strong>${v(p)}</strong> (${v(f)})`),
                 (t.innerHTML = e));
         }
-        Ne(
+        ze(
             'Modo solo lectura: gestiona horarios directamente en Google Calendar.'
         );
     } else
         ((e.innerHTML = 'Fuente: <strong>Configuracion local</strong>'),
             t && (t.innerHTML = `Snapshot: <strong>${v(u)}</strong>`),
-            Ne(
+            ze(
                 'Selecciona un dia para revisar horarios y agregar o eliminar slots.'
             ));
     if (
@@ -1404,8 +1463,8 @@ function He() {
                         ? 'Horarios del Dia (solo lectura)'
                         : 'Horarios del Dia');
         })(a),
-        _e(),
-        Pe(),
+        We(),
+        Je(),
         !n)
     )
         return;
@@ -1425,32 +1484,32 @@ function He() {
         y('narvaez', 'Dra. Narvaez'),
     ].join(' | ');
 }
-function Re() {
+function Ke() {
     const e = document.getElementById('selectedDate');
-    (e && (e.textContent = 'Selecciona una fecha'), Me(0));
+    (e && (e.textContent = 'Selecciona una fecha'), Ge(0));
     const t = document.getElementById('timeSlotsList');
     (t &&
         (t.innerHTML =
             '<p class="empty-message">Selecciona una fecha para ver los horarios</p>'),
-        xe(),
-        _e(),
-        Pe());
+        Ye(),
+        We(),
+        Je());
 }
-function xe() {
-    const e = Boolean(String(ye || '').trim()),
+function Ye() {
+    const e = Boolean(String(Ae || '').trim()),
         t = document.getElementById('addSlotForm');
-    t && t.classList.toggle('is-hidden', be || !e);
+    t && t.classList.toggle('is-hidden', De || !e);
     const n = document.getElementById('availabilityQuickSlotPresets');
     (n &&
-        (n.classList.toggle('is-hidden', be || !e),
+        (n.classList.toggle('is-hidden', De || !e),
         n.querySelectorAll('.slot-preset-btn').forEach((t) => {
-            t.disabled = be || !e;
+            t.disabled = De || !e;
         })),
-        Pe());
+        Je());
 }
-function je() {
-    const e = he.getFullYear(),
-        t = he.getMonth(),
+function Ze() {
+    const e = Ie.getFullYear(),
+        t = Ie.getMonth(),
         n = new Date(e, t, 1).getDay(),
         o = new Date(e, t + 1, 0).getDate(),
         i = new Date(e, t, 0).getDate();
@@ -1460,7 +1519,7 @@ function je() {
     ).toLocaleDateString('es-EC', { month: 'long', year: 'numeric' });
     const r = document.getElementById('availabilityCalendar');
     r.innerHTML = '';
-    const s = Se(new Date());
+    const s = Me(new Date());
     ['Dom', 'Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab'].forEach((e) => {
         const t = document.createElement('div');
         ((t.className = 'calendar-day-header'),
@@ -1475,20 +1534,20 @@ function je() {
             r.appendChild(n));
     }
     for (let n = 1; n <= o; n += 1) {
-        const o = Se(new Date(e, t, n)),
+        const o = Me(new Date(e, t, n)),
             i = document.createElement('div');
         ((i.className = 'calendar-day'),
             (i.textContent = n),
             (i.tabIndex = 0),
             i.setAttribute('role', 'button'),
             i.setAttribute('aria-label', `Seleccionar ${o}`),
-            ye === o && i.classList.add('selected'),
+            Ae === o && i.classList.add('selected'),
             s === o && i.classList.add('today'),
             a[o] && a[o].length > 0 && i.classList.add('has-slots'),
-            i.addEventListener('click', () => Fe(o)),
+            i.addEventListener('click', () => Qe(o)),
             i.addEventListener('keydown', (e) => {
                 ('Enter' !== e.key && ' ' !== e.key) ||
-                    (e.preventDefault(), Fe(o));
+                    (e.preventDefault(), Qe(o));
             }),
             r.appendChild(i));
     }
@@ -1500,9 +1559,9 @@ function je() {
             r.appendChild(t));
     }
 }
-function Fe(e) {
-    ((ye = e), je());
-    const t = Ee(e) || new Date(e);
+function Qe(e) {
+    ((Ae = e), Ze());
+    const t = _e(e) || new Date(e);
     ((document.getElementById('selectedDate').textContent =
         t.toLocaleDateString('es-EC', {
             weekday: 'long',
@@ -1510,19 +1569,19 @@ function Fe(e) {
             month: 'long',
             year: 'numeric',
         })),
-        xe(),
-        _e(),
-        Oe(e));
+        Ye(),
+        We(),
+        Xe(e));
 }
-function Oe(e) {
+function Xe(e) {
     const t = a[e] || [],
         n = document.getElementById('timeSlotsList');
-    if ((Me(t.length), 0 === t.length))
+    if ((Ge(t.length), 0 === t.length))
         return (
             (n.innerHTML =
                 '<p class="empty-message">No hay horarios configurados para este dia</p>'),
-            _e(),
-            void Pe()
+            We(),
+            void Je()
         );
     const o = encodeURIComponent(String(e || ''));
     ((n.innerHTML = t
@@ -1530,55 +1589,55 @@ function Oe(e) {
         .sort()
         .map(
             (e) =>
-                `\n        <div class="time-slot-item${be ? ' is-readonly' : ''}">\n            <span class="time">${v(e)}</span>\n            <div class="slot-actions">\n                ${be ? '<span class="slot-readonly-tag">Solo lectura</span>' : `<button type="button" class="btn-icon danger" data-action="remove-time-slot" data-date="${o}" data-time="${encodeURIComponent(String(e || ''))}">\n                    <i class="fas fa-trash"></i>\n                </button>`}\n            </div>\n        </div>\n    `
+                `\n        <div class="time-slot-item${De ? ' is-readonly' : ''}">\n            <span class="time">${v(e)}</span>\n            <div class="slot-actions">\n                ${De ? '<span class="slot-readonly-tag">Solo lectura</span>' : `<button type="button" class="btn-icon danger" data-action="remove-time-slot" data-date="${o}" data-time="${encodeURIComponent(String(e || ''))}">\n                    <i class="fas fa-trash"></i>\n                </button>`}\n            </div>\n        </div>\n    `
         )
         .join('')),
-        _e(),
-        Pe());
+        We(),
+        Je());
 }
-async function qe() {
-    if (be)
+async function et() {
+    if (De)
         throw new Error('Disponibilidad en solo lectura (Google Calendar).');
     await h('availability', { method: 'POST', body: { availability: a } });
 }
-function Ue() {
-    return be
+function tt() {
+    return De
         ? (w(
               'Disponibilidad en solo lectura: gestionala desde Google Calendar.',
               'warning'
           ),
           !1)
-        : !!ye || (w('Selecciona una fecha primero', 'warning'), !1);
+        : !!Ae || (w('Selecciona una fecha primero', 'warning'), !1);
 }
-const ze = [
+const nt = [
     'a[href]',
     'button:not([disabled])',
     '[tabindex]:not([tabindex="-1"])',
 ].join(',');
-function Ge() {
+function at() {
     return Array.from(document.querySelectorAll('.nav-item[data-section]'));
 }
-function We() {
+function ot() {
     const e = window.location.hash.replace(/^#/, '').trim();
-    return new Set(Ge().map((e) => e.dataset.section)).has(e) ? e : 'dashboard';
+    return new Set(at().map((e) => e.dataset.section)).has(e) ? e : 'dashboard';
 }
-function Je() {
+function it() {
     return (
         document.querySelector('.nav-item.active')?.dataset.section ||
-        We() ||
+        ot() ||
         'dashboard'
     );
 }
-function Ve() {
+function rt() {
     return window.innerWidth <= 1024;
 }
-function Ke() {
+function st() {
     return Boolean(
         document.getElementById('adminSidebar')?.classList.contains('is-open')
     );
 }
-function Ye(e) {
-    Ge().forEach((t) => {
+function ct(e) {
+    at().forEach((t) => {
         const n = t.dataset.section === e;
         (t.classList.toggle('active', n),
             n
@@ -1586,17 +1645,17 @@ function Ye(e) {
                 : t.removeAttribute('aria-current'));
     });
 }
-function Ze() {
+function lt() {
     return {
         sidebar: document.getElementById('adminSidebar'),
         backdrop: document.getElementById('adminSidebarBackdrop'),
         toggleBtn: document.getElementById('adminMenuToggle'),
     };
 }
-function Qe() {
+function dt() {
     const e = document.getElementById('adminSidebar');
     return e
-        ? Array.from(e.querySelectorAll(ze)).filter(
+        ? Array.from(e.querySelectorAll(nt)).filter(
               (e) =>
                   e instanceof HTMLElement &&
                   !e.hasAttribute('disabled') &&
@@ -1604,10 +1663,10 @@ function Qe() {
           )
         : [];
 }
-function Xe(e) {
+function ut(e) {
     const t = document.getElementById('adminSidebar'),
         n = document.getElementById('adminMainContent'),
-        a = Ve(),
+        a = rt(),
         o = Boolean(a && e);
     (t && t.setAttribute('aria-hidden', String(!o && a)),
         n &&
@@ -1615,16 +1674,16 @@ function Xe(e) {
                 ? n.setAttribute('aria-hidden', 'true')
                 : n.removeAttribute('aria-hidden')));
 }
-function et(e) {
-    const { sidebar: t, backdrop: n, toggleBtn: a } = Ze();
+function mt(e) {
+    const { sidebar: t, backdrop: n, toggleBtn: a } = lt();
     if (!t || !n || !a) return;
-    const o = Boolean(e && Ve());
+    const o = Boolean(e && rt());
     (t.classList.toggle('is-open', o),
         n.classList.toggle('is-hidden', !o),
         n.setAttribute('aria-hidden', String(!o)),
         document.body.classList.toggle('admin-sidebar-open', o),
         a.setAttribute('aria-expanded', String(o)),
-        Xe(o),
+        ut(o),
         o &&
             (function () {
                 const e = document.getElementById('adminSidebar');
@@ -1635,18 +1694,18 @@ function et(e) {
                         t.scrollIntoView({ block: 'nearest' }),
                         void t.focus()
                     );
-                const n = Qe();
+                const n = dt();
                 n[0] instanceof HTMLElement ? n[0].focus() : e.focus();
             })());
 }
-function tt({ restoreFocus: e = !1 } = {}) {
-    const { toggleBtn: t } = Ze(),
+function pt({ restoreFocus: e = !1 } = {}) {
+    const { toggleBtn: t } = lt(),
         n = document
             .getElementById('adminSidebar')
             ?.classList.contains('is-open');
-    (et(!1), e && n && t && t.focus());
+    (mt(!1), e && n && t && t.focus());
 }
-async function nt(e, t = {}) {
+async function ft(e, t = {}) {
     const {
             refresh: n = !0,
             updateHash: a = !0,
@@ -1654,7 +1713,7 @@ async function nt(e, t = {}) {
             closeMobileNav: i = !0,
         } = t,
         r = e || 'dashboard';
-    if ((Ye(r), i && tt(), n))
+    if ((ct(r), i && pt(), n))
         try {
             await M();
         } catch (e) {
@@ -1663,7 +1722,7 @@ async function nt(e, t = {}) {
                 'warning'
             );
         }
-    (await at(r),
+    (await gt(r),
         a &&
             (function (e) {
                 const t = `#${e}`;
@@ -1685,7 +1744,7 @@ async function nt(e, t = {}) {
                     }));
             })(r));
 }
-async function at(e) {
+async function gt(e) {
     const t = document.getElementById('pageTitle');
     (t &&
         (t.textContent =
@@ -1706,7 +1765,7 @@ async function at(e) {
             O();
             break;
         case 'appointments':
-            fe();
+            Ce();
             break;
         case 'callbacks':
             U();
@@ -1789,33 +1848,33 @@ async function at(e) {
                             };
                         (u(t),
                             m(r),
-                            (be = 'google' === String(r.source || '')),
-                            He(),
-                            xe(),
-                            ye && !a[ye] && ((ye = null), Re()));
+                            (De = 'google' === String(r.source || '')),
+                            Ve(),
+                            Ye(),
+                            Ae && !a[Ae] && ((Ae = null), Ke()));
                     } catch (e) {
                         (console.error('Error refreshing availability:', e),
                             w(
                                 `Error al actualizar disponibilidad: ${e?.message || 'error desconocido'}`,
                                 'error'
                             ),
-                            (be = 'google' === String(o.source || '')),
-                            He(),
-                            xe());
+                            (De = 'google' === String(o.source || '')),
+                            Ve(),
+                            Ye());
                     }
                 })(),
-                    je(),
-                    ye ? (xe(), _e()) : Re());
+                    Ze(),
+                    Ae ? (Ye(), We()) : Ke());
             })();
     }
 }
-async function ot() {
+async function yt() {
     const e = document.getElementById('loginScreen'),
         t = document.getElementById('adminDashboard');
     (e && e.classList.add('is-hidden'),
         t && t.classList.remove('is-hidden'),
-        Ye(We()),
-        tt(),
+        ct(ot()),
+        pt(),
         await (async function () {
             const e = document.getElementById('currentDate');
             if (e) {
@@ -1835,8 +1894,8 @@ async function ot() {
                     'warning'
                 );
             }
-            const t = Je();
-            await at(t);
+            const t = it();
+            await gt(t);
         })(),
         await (async function () {
             if (G) return;
@@ -1864,7 +1923,7 @@ async function ot() {
             }
         })());
 }
-async function it(e) {
+async function ht(e) {
     e.preventDefault();
     const t = document.getElementById('group2FA');
     if (t && !t.classList.contains('is-hidden')) {
@@ -1875,7 +1934,7 @@ async function it(e) {
             })(e);
             (t.csrfToken && g(t.csrfToken),
                 w('Bienvenido al panel de administracion', 'success'),
-                await ot());
+                await yt());
         } catch {
             w('Codigo incorrecto o sesion expirada', 'error');
         }
@@ -1900,618 +1959,658 @@ async function it(e) {
         }
         (e.csrfToken && g(e.csrfToken),
             w('Bienvenido al panel de administracion', 'success'),
-            await ot());
+            await yt());
     } catch {
         w('Contrasena incorrecta', 'error');
     }
 }
 document.addEventListener('DOMContentLoaded', async () => {
-    ((function () {
-        document.addEventListener('click', async (o) => {
-            const i = o.target.closest('[data-action]');
-            if (!i) return;
-            const r = i.dataset.action;
-            if ('close-toast' !== r) {
-                if ('logout' === r)
-                    return (
-                        o.preventDefault(),
-                        void (await (async function () {
-                            try {
-                                await b('logout', { method: 'POST' });
-                            } catch (e) {}
-                            (w('Sesion cerrada correctamente', 'info'),
-                                setTimeout(
-                                    () => window.location.reload(),
-                                    800
-                                ));
-                        })())
-                    );
-                if ('export-data' === r)
-                    return (
-                        o.preventDefault(),
-                        void (function () {
-                            const o = {
-                                    appointments: e,
-                                    callbacks: t,
-                                    reviews: n,
-                                    availability: a,
-                                    exportDate: new Date().toISOString(),
-                                },
-                                i = new Blob([JSON.stringify(o, null, 2)], {
-                                    type: 'application/json',
-                                }),
-                                r = URL.createObjectURL(i),
-                                s = document.createElement('a');
-                            ((s.href = r),
-                                (s.download = `piel-en-armonia-backup-${new Date().toISOString().split('T')[0]}.json`),
-                                document.body.appendChild(s),
-                                s.click(),
-                                document.body.removeChild(s),
-                                URL.revokeObjectURL(r),
-                                w('Datos exportados correctamente', 'success'));
-                        })()
-                    );
-                if ('open-import-file' === r)
-                    return (
-                        o.preventDefault(),
-                        void document.getElementById('importFileInput')?.click()
-                    );
-                try {
-                    if ('export-csv' === r)
+    ((ae = (function () {
+        try {
+            const e = localStorage.getItem(te) || 'system';
+            return ce(e) ? e : 'system';
+        } catch (e) {
+            return 'system';
+        }
+    })()),
+        ue(ae, { persist: !1, animate: !1 }),
+        (function () {
+            if (ie) return;
+            const e = se();
+            e &&
+                ('function' == typeof e.addEventListener
+                    ? (e.addEventListener('change', me), (ie = !0))
+                    : 'function' == typeof e.addListener &&
+                      (e.addListener(me), (ie = !0)));
+        })(),
+        (function () {
+            document.addEventListener('click', async (o) => {
+                const i = o.target.closest('[data-action]');
+                if (!i) return;
+                const r = i.dataset.action;
+                if ('close-toast' !== r) {
+                    if ('logout' === r)
+                        return (
+                            o.preventDefault(),
+                            void (await (async function () {
+                                try {
+                                    await b('logout', { method: 'POST' });
+                                } catch (e) {}
+                                (w('Sesion cerrada correctamente', 'info'),
+                                    setTimeout(
+                                        () => window.location.reload(),
+                                        800
+                                    ));
+                            })())
+                        );
+                    if ('export-data' === r)
                         return (
                             o.preventDefault(),
                             void (function () {
-                                if (!Array.isArray(e) || 0 === e.length)
-                                    return void w(
-                                        'No hay citas para exportar',
-                                        'warning'
-                                    );
-                                const t = e.map((e) => [
-                                        Number(e.id) || 0,
-                                        e.date || '',
-                                        e.time || '',
-                                        ge(e.name || ''),
-                                        ge(e.email || ''),
-                                        ge(e.phone || ''),
-                                        ge(B(e.service)),
-                                        ge(C(e.doctor)),
-                                        e.price || '',
-                                        ge($(e.status || 'confirmed')),
-                                        ge(A(e.paymentStatus)),
-                                        ge(L(e.paymentMethod)),
-                                    ]),
-                                    n = [
-                                        [
-                                            'ID',
-                                            'Fecha',
-                                            'Hora',
-                                            'Paciente',
-                                            'Email',
-                                            'Telefono',
-                                            'Servicio',
-                                            'Doctor',
-                                            'Precio',
-                                            'Estado',
-                                            'Estado pago',
-                                            'Metodo pago',
-                                        ].join(','),
-                                        ...t.map((e) => e.join(',')),
-                                    ].join('\n'),
-                                    a = new Blob([n], {
-                                        type: 'text/csv;charset=utf-8;',
+                                const o = {
+                                        appointments: e,
+                                        callbacks: t,
+                                        reviews: n,
+                                        availability: a,
+                                        exportDate: new Date().toISOString(),
+                                    },
+                                    i = new Blob([JSON.stringify(o, null, 2)], {
+                                        type: 'application/json',
                                     }),
-                                    o = URL.createObjectURL(a),
-                                    i = document.createElement('a');
-                                ((i.href = o),
-                                    (i.download = `citas-pielarmonia-${new Date().toISOString().split('T')[0]}.csv`),
-                                    document.body.appendChild(i),
-                                    i.click(),
-                                    document.body.removeChild(i),
-                                    URL.revokeObjectURL(o),
+                                    r = URL.createObjectURL(i),
+                                    s = document.createElement('a');
+                                ((s.href = r),
+                                    (s.download = `piel-en-armonia-backup-${new Date().toISOString().split('T')[0]}.json`),
+                                    document.body.appendChild(s),
+                                    s.click(),
+                                    document.body.removeChild(s),
+                                    URL.revokeObjectURL(r),
                                     w(
-                                        'CSV exportado correctamente',
+                                        'Datos exportados correctamente',
                                         'success'
                                     ));
                             })()
                         );
-                    if ('clear-appointment-filters' === r)
+                    if ('open-import-file' === r)
                         return (
                             o.preventDefault(),
-                            void (function () {
-                                const { filterSelect: e, searchInput: t } =
-                                    se();
-                                (e && (e.value = 'all'),
-                                    t && (t.value = ''),
-                                    pe());
-                            })()
+                            void document
+                                .getElementById('importFileInput')
+                                ?.click()
                         );
-                    if ('appointment-density' === r)
+                    if ('set-admin-theme' === r)
                         return (
                             o.preventDefault(),
-                            void (function (e) {
-                                const t = le(e);
-                                (ue(t),
-                                    de(ne, t),
-                                    Boolean(
-                                        document.getElementById(
-                                            'appointmentsTableBody'
-                                        )
-                                    ) && pe());
-                            })(i.dataset.density || 'comfortable')
+                            void ue(i.dataset.themeMode || 'system', {
+                                persist: !0,
+                                animate: !0,
+                            })
                         );
-                    if ('change-month' === r)
-                        return (
-                            o.preventDefault(),
-                            (s = Number(i.dataset.delta || 0)),
-                            he.setMonth(he.getMonth() + s),
-                            void je()
-                        );
-                    if ('availability-today' === r)
-                        return (
-                            o.preventDefault(),
-                            void (function () {
-                                const e = new Date();
-                                ((he = new Date(
-                                    e.getFullYear(),
-                                    e.getMonth(),
-                                    1
-                                )),
-                                    je(),
-                                    Fe(Se(e)));
-                            })()
-                        );
-                    if ('prefill-time-slot' === r)
-                        return (
-                            o.preventDefault(),
-                            void (function (e) {
-                                if (be)
-                                    return void w(
-                                        'Disponibilidad en solo lectura: gestionala desde Google Calendar.',
-                                        'warning'
-                                    );
-                                const t =
-                                    document.getElementById('newSlotTime');
-                                t instanceof HTMLInputElement &&
-                                    ((t.value = String(e || '').trim()),
-                                    t.focus());
-                            })(i.dataset.time || '')
-                        );
-                    if ('copy-availability-day' === r)
-                        return (
-                            o.preventDefault(),
-                            void (function () {
-                                if (!ye)
-                                    return void w(
-                                        'Selecciona una fecha para copiar',
-                                        'warning'
-                                    );
-                                const e = Ae();
-                                0 !== e.length
-                                    ? ($e(ye, e),
-                                      Pe(),
-                                      w(
-                                          `Dia copiado (${e.length} horario${1 === e.length ? '' : 's'})`,
-                                          'success'
-                                      ))
-                                    : w(
-                                          'No hay horarios para copiar en este dia',
-                                          'warning'
-                                      );
-                            })()
-                        );
-                    if ('paste-availability-day' === r)
-                        return (
-                            o.preventDefault(),
-                            void (await (async function () {
-                                if ((ke(), !Ue())) return;
-                                const e = Ce(ve?.slots || []);
-                                if (0 === e.length)
-                                    return void w(
-                                        'Portapapeles vacio',
-                                        'warning'
-                                    );
-                                const t = Ae();
-                                if (
-                                    t.length === e.length &&
-                                    t.every((t, n) => t === e[n])
-                                )
-                                    w(
-                                        'La fecha ya tiene esos mismos horarios',
-                                        'warning'
-                                    );
-                                else if (
-                                    !(t.length > 0) ||
-                                    confirm(
-                                        `Reemplazar ${t.length} horario${1 === t.length ? '' : 's'} en ${Le(ye)} con ${e.length}?`
-                                    )
-                                )
-                                    try {
-                                        (Ie(ye, e),
-                                            await qe(),
-                                            De(ye),
-                                            Fe(ye),
-                                            w(
-                                                'Horarios pegados en la fecha seleccionada',
-                                                'success'
-                                            ));
-                                    } catch (e) {
-                                        w(
-                                            `No se pudieron pegar los horarios: ${e.message}`,
-                                            'error'
+                    var s;
+                    try {
+                        if ('export-csv' === r)
+                            return (
+                                o.preventDefault(),
+                                void (function () {
+                                    if (!Array.isArray(e) || 0 === e.length)
+                                        return void w(
+                                            'No hay citas para exportar',
+                                            'warning'
                                         );
-                                    }
-                            })())
-                        );
-                    if ('duplicate-availability-day-next' === r)
-                        return (
-                            o.preventDefault(),
-                            void (await (async function () {
-                                if (!Ue()) return;
-                                const e = Ae();
-                                if (0 === e.length)
-                                    return void w(
-                                        'No hay horarios para duplicar en este dia',
-                                        'warning'
-                                    );
-                                const t = Ee(ye);
-                                if (!t)
-                                    return void w(
-                                        'Fecha seleccionada invalida',
-                                        'error'
-                                    );
-                                const n = new Date(t);
-                                n.setDate(t.getDate() + 1);
-                                const o = Se(n),
-                                    i = Ce(a[o] || []);
-                                if (
-                                    !(i.length > 0) ||
-                                    confirm(
-                                        `${Le(o)} ya tiene ${i.length} horario${1 === i.length ? '' : 's'}. Deseas reemplazarlos?`
-                                    )
-                                )
-                                    try {
-                                        (Ie(o, e),
-                                            $e(ye, e),
-                                            await qe(),
-                                            De(o),
-                                            Fe(o),
-                                            w(
-                                                `Horarios duplicados a ${Le(o)}`,
-                                                'success'
-                                            ));
-                                    } catch (e) {
-                                        w(
-                                            `No se pudo duplicar el dia: ${e.message}`,
-                                            'error'
-                                        );
-                                    }
-                            })())
-                        );
-                    if ('clear-availability-day' === r)
-                        return (
-                            o.preventDefault(),
-                            void (await (async function () {
-                                if (!Ue()) return;
-                                const e = Ae();
-                                if (0 !== e.length) {
-                                    if (
-                                        confirm(
-                                            `Eliminar ${e.length} horario${1 === e.length ? '' : 's'} de ${Le(ye)}?`
-                                        )
-                                    )
-                                        try {
-                                            (Ie(ye, []),
-                                                await qe(),
-                                                De(ye),
-                                                Fe(ye),
-                                                w(
-                                                    'Horarios del dia eliminados',
-                                                    'success'
-                                                ));
-                                        } catch (e) {
-                                            w(
-                                                `No se pudo limpiar el dia: ${e.message}`,
-                                                'error'
-                                            );
-                                        }
-                                } else
-                                    w(
-                                        'No hay horarios que limpiar en este dia',
-                                        'warning'
-                                    );
-                            })())
-                        );
-                    if ('add-time-slot' === r)
-                        return (
-                            o.preventDefault(),
-                            void (await (async function () {
-                                if (be)
-                                    return void w(
-                                        'Disponibilidad en solo lectura: gestionala desde Google Calendar.',
-                                        'warning'
-                                    );
-                                if (!ye)
-                                    return void w(
-                                        'Selecciona una fecha primero',
-                                        'warning'
-                                    );
-                                const e =
-                                    document.getElementById(
-                                        'newSlotTime'
-                                    ).value;
-                                if (e)
-                                    if (
-                                        (a[ye] || (a[ye] = []),
-                                        a[ye].includes(e))
-                                    )
-                                        w('Este horario ya existe', 'warning');
-                                    else
-                                        try {
-                                            (a[ye].push(e),
-                                                await qe(),
-                                                Oe(ye),
-                                                je(),
-                                                (document.getElementById(
-                                                    'newSlotTime'
-                                                ).value = ''),
-                                                w(
-                                                    'Horario agregado',
-                                                    'success'
-                                                ));
-                                        } catch (e) {
-                                            w(
-                                                `No se pudo guardar el horario: ${e.message}`,
-                                                'error'
-                                            );
-                                        }
-                                else w('Ingresa un horario', 'warning');
-                            })())
-                        );
-                    if ('remove-time-slot' === r)
-                        return (
-                            o.preventDefault(),
-                            void (await (async function (e, t) {
-                                if (be)
-                                    w(
-                                        'Disponibilidad en solo lectura: gestionala desde Google Calendar.',
-                                        'warning'
-                                    );
-                                else
-                                    try {
-                                        ((a[e] = (a[e] || []).filter(
-                                            (e) => e !== t
-                                        )),
-                                            await qe(),
-                                            Oe(e),
-                                            je(),
-                                            w('Horario eliminado', 'success'));
-                                    } catch (e) {
-                                        w(
-                                            `No se pudo eliminar el horario: ${e.message}`,
-                                            'error'
-                                        );
-                                    }
-                            })(
-                                decodeURIComponent(i.dataset.date || ''),
-                                decodeURIComponent(i.dataset.time || '')
-                            ))
-                        );
-                    if ('approve-transfer' === r)
-                        return (
-                            o.preventDefault(),
-                            void (await (async function (e) {
-                                if (
-                                    confirm(
-                                        '¿Aprobar el comprobante de transferencia de esta cita?'
-                                    )
-                                )
-                                    if (e)
-                                        try {
-                                            (await h('appointments', {
-                                                method: 'PATCH',
-                                                body: {
-                                                    id: e,
-                                                    paymentStatus: 'paid',
-                                                    paymentPaidAt:
-                                                        new Date().toISOString(),
-                                                },
-                                            }),
-                                                await M(),
-                                                fe(),
-                                                O(),
-                                                w(
-                                                    'Transferencia aprobada',
-                                                    'success'
-                                                ));
-                                        } catch (e) {
-                                            w(
-                                                `No se pudo aprobar: ${e.message}`,
-                                                'error'
-                                            );
-                                        }
-                                    else w('Id de cita invalido', 'error');
-                            })(Number(i.dataset.id || 0)))
-                        );
-                    if ('reject-transfer' === r)
-                        return (
-                            o.preventDefault(),
-                            void (await (async function (e) {
-                                if (
-                                    confirm(
-                                        '¿Rechazar el comprobante de transferencia? La cita quedará como pago fallido.'
-                                    )
-                                )
-                                    if (e)
-                                        try {
-                                            (await h('appointments', {
-                                                method: 'PATCH',
-                                                body: {
-                                                    id: e,
-                                                    paymentStatus: 'failed',
-                                                },
-                                            }),
-                                                await M(),
-                                                fe(),
-                                                O(),
-                                                w(
-                                                    'Transferencia rechazada',
-                                                    'warning'
-                                                ));
-                                        } catch (e) {
-                                            w(
-                                                `No se pudo rechazar: ${e.message}`,
-                                                'error'
-                                            );
-                                        }
-                                    else w('Id de cita invalido', 'error');
-                            })(Number(i.dataset.id || 0)))
-                        );
-                    if ('cancel-appointment' === r)
-                        return (
-                            o.preventDefault(),
-                            void (await (async function (e) {
-                                if (
-                                    confirm(
-                                        '¿Estas seguro de cancelar esta cita?'
-                                    )
-                                )
-                                    if (e)
-                                        try {
-                                            (await h('appointments', {
-                                                method: 'PATCH',
-                                                body: {
-                                                    id: e,
-                                                    status: 'cancelled',
-                                                },
-                                            }),
-                                                await M(),
-                                                fe(),
-                                                O(),
-                                                w(
-                                                    'Cita cancelada correctamente',
-                                                    'success'
-                                                ));
-                                        } catch (e) {
-                                            w(
-                                                `No se pudo cancelar la cita: ${e.message}`,
-                                                'error'
-                                            );
-                                        }
-                                    else w('Id de cita invalido', 'error');
-                            })(Number(i.dataset.id || 0)))
-                        );
-                    if ('mark-no-show' === r)
-                        return (
-                            o.preventDefault(),
-                            void (await (async function (e) {
-                                if (
-                                    confirm(
-                                        'Marcar esta cita como "No asistio"?'
-                                    )
-                                )
-                                    if (e)
-                                        try {
-                                            (await h('appointments', {
-                                                method: 'PATCH',
-                                                body: {
-                                                    id: e,
-                                                    status: 'no_show',
-                                                },
-                                            }),
-                                                await M(),
-                                                fe(),
-                                                O(),
-                                                w(
-                                                    'Cita marcada como no asistio',
-                                                    'success'
-                                                ));
-                                        } catch (e) {
-                                            w(
-                                                `No se pudo marcar no-show: ${e.message}`,
-                                                'error'
-                                            );
-                                        }
-                                    else w('Id de cita invalido', 'error');
-                            })(Number(i.dataset.id || 0)))
-                        );
-                    'mark-contacted' === r &&
-                        (o.preventDefault(),
-                        await (async function (e, n = '') {
-                            let a = null;
-                            const o = Number(e);
-                            o > 0 && (a = t.find((e) => Number(e.id) === o));
-                            const i = n ? decodeURIComponent(n) : '';
-                            if (
-                                (!a && i && (a = t.find((e) => e.fecha === i)),
-                                a)
-                            )
-                                try {
-                                    const e = a.id || Date.now();
-                                    (a.id || (a.id = e),
-                                        await h('callbacks', {
-                                            method: 'PATCH',
-                                            body: {
-                                                id: Number(e),
-                                                status: 'contactado',
-                                            },
+                                    const t = e.map((e) => [
+                                            Number(e.id) || 0,
+                                            e.date || '',
+                                            e.time || '',
+                                            $e(e.name || ''),
+                                            $e(e.email || ''),
+                                            $e(e.phone || ''),
+                                            $e(B(e.service)),
+                                            $e(L(e.doctor)),
+                                            e.price || '',
+                                            $e(C(e.status || 'confirmed')),
+                                            $e(A(e.paymentStatus)),
+                                            $e($(e.paymentMethod)),
+                                        ]),
+                                        n = [
+                                            [
+                                                'ID',
+                                                'Fecha',
+                                                'Hora',
+                                                'Paciente',
+                                                'Email',
+                                                'Telefono',
+                                                'Servicio',
+                                                'Doctor',
+                                                'Precio',
+                                                'Estado',
+                                                'Estado pago',
+                                                'Metodo pago',
+                                            ].join(','),
+                                            ...t.map((e) => e.join(',')),
+                                        ].join('\n'),
+                                        a = new Blob([n], {
+                                            type: 'text/csv;charset=utf-8;',
                                         }),
-                                        await M(),
-                                        U(),
-                                        O(),
+                                        o = URL.createObjectURL(a),
+                                        i = document.createElement('a');
+                                    ((i.href = o),
+                                        (i.download = `citas-pielarmonia-${new Date().toISOString().split('T')[0]}.csv`),
+                                        document.body.appendChild(i),
+                                        i.click(),
+                                        document.body.removeChild(i),
+                                        URL.revokeObjectURL(o),
                                         w(
-                                            'Marcado como contactado',
+                                            'CSV exportado correctamente',
                                             'success'
                                         ));
-                                } catch (e) {
-                                    w(
-                                        `No se pudo actualizar callback: ${e.message}`,
-                                        'error'
-                                    );
-                                }
-                            else w('Callback no encontrado', 'error');
-                        })(
-                            Number(i.dataset.callbackId || 0),
-                            i.dataset.callbackDate || ''
-                        ));
-                } catch (e) {
-                    w(`Error ejecutando accion: ${e.message}`, 'error');
-                }
-                var s;
-            } else i.closest('.toast')?.remove();
-        });
-        const o = document.getElementById('appointmentFilter');
-        o &&
-            o.addEventListener('change', () => {
-                pe();
+                                })()
+                            );
+                        if ('clear-appointment-filters' === r)
+                            return (
+                                o.preventDefault(),
+                                void (function () {
+                                    const { filterSelect: e, searchInput: t } =
+                                        ve();
+                                    (e && (e.value = 'all'),
+                                        t && (t.value = ''),
+                                        Le());
+                                })()
+                            );
+                        if ('appointment-density' === r)
+                            return (
+                                o.preventDefault(),
+                                void (function (e) {
+                                    const t = Se(e);
+                                    (ke(t),
+                                        Ee(fe, t),
+                                        Boolean(
+                                            document.getElementById(
+                                                'appointmentsTableBody'
+                                            )
+                                        ) && Le());
+                                })(i.dataset.density || 'comfortable')
+                            );
+                        if ('change-month' === r)
+                            return (
+                                o.preventDefault(),
+                                (s = Number(i.dataset.delta || 0)),
+                                Ie.setMonth(Ie.getMonth() + s),
+                                void Ze()
+                            );
+                        if ('availability-today' === r)
+                            return (
+                                o.preventDefault(),
+                                void (function () {
+                                    const e = new Date();
+                                    ((Ie = new Date(
+                                        e.getFullYear(),
+                                        e.getMonth(),
+                                        1
+                                    )),
+                                        Ze(),
+                                        Qe(Me(e)));
+                                })()
+                            );
+                        if ('prefill-time-slot' === r)
+                            return (
+                                o.preventDefault(),
+                                void (function (e) {
+                                    if (De)
+                                        return void w(
+                                            'Disponibilidad en solo lectura: gestionala desde Google Calendar.',
+                                            'warning'
+                                        );
+                                    const t =
+                                        document.getElementById('newSlotTime');
+                                    t instanceof HTMLInputElement &&
+                                        ((t.value = String(e || '').trim()),
+                                        t.focus());
+                                })(i.dataset.time || '')
+                            );
+                        if ('copy-availability-day' === r)
+                            return (
+                                o.preventDefault(),
+                                void (function () {
+                                    if (!Ae)
+                                        return void w(
+                                            'Selecciona una fecha para copiar',
+                                            'warning'
+                                        );
+                                    const e = Fe();
+                                    0 !== e.length
+                                        ? (xe(Ae, e),
+                                          Je(),
+                                          w(
+                                              `Dia copiado (${e.length} horario${1 === e.length ? '' : 's'})`,
+                                              'success'
+                                          ))
+                                        : w(
+                                              'No hay horarios para copiar en este dia',
+                                              'warning'
+                                          );
+                                })()
+                            );
+                        if ('paste-availability-day' === r)
+                            return (
+                                o.preventDefault(),
+                                void (await (async function () {
+                                    if ((Pe(), !tt())) return;
+                                    const e = Re(Te?.slots || []);
+                                    if (0 === e.length)
+                                        return void w(
+                                            'Portapapeles vacio',
+                                            'warning'
+                                        );
+                                    const t = Fe();
+                                    if (
+                                        t.length === e.length &&
+                                        t.every((t, n) => t === e[n])
+                                    )
+                                        w(
+                                            'La fecha ya tiene esos mismos horarios',
+                                            'warning'
+                                        );
+                                    else if (
+                                        !(t.length > 0) ||
+                                        confirm(
+                                            `Reemplazar ${t.length} horario${1 === t.length ? '' : 's'} en ${je(Ae)} con ${e.length}?`
+                                        )
+                                    )
+                                        try {
+                                            (Oe(Ae, e),
+                                                await et(),
+                                                qe(Ae),
+                                                Qe(Ae),
+                                                w(
+                                                    'Horarios pegados en la fecha seleccionada',
+                                                    'success'
+                                                ));
+                                        } catch (e) {
+                                            w(
+                                                `No se pudieron pegar los horarios: ${e.message}`,
+                                                'error'
+                                            );
+                                        }
+                                })())
+                            );
+                        if ('duplicate-availability-day-next' === r)
+                            return (
+                                o.preventDefault(),
+                                void (await (async function () {
+                                    if (!tt()) return;
+                                    const e = Fe();
+                                    if (0 === e.length)
+                                        return void w(
+                                            'No hay horarios para duplicar en este dia',
+                                            'warning'
+                                        );
+                                    const t = _e(Ae);
+                                    if (!t)
+                                        return void w(
+                                            'Fecha seleccionada invalida',
+                                            'error'
+                                        );
+                                    const n = new Date(t);
+                                    n.setDate(t.getDate() + 1);
+                                    const o = Me(n),
+                                        i = Re(a[o] || []);
+                                    if (
+                                        !(i.length > 0) ||
+                                        confirm(
+                                            `${je(o)} ya tiene ${i.length} horario${1 === i.length ? '' : 's'}. Deseas reemplazarlos?`
+                                        )
+                                    )
+                                        try {
+                                            (Oe(o, e),
+                                                xe(Ae, e),
+                                                await et(),
+                                                qe(o),
+                                                Qe(o),
+                                                w(
+                                                    `Horarios duplicados a ${je(o)}`,
+                                                    'success'
+                                                ));
+                                        } catch (e) {
+                                            w(
+                                                `No se pudo duplicar el dia: ${e.message}`,
+                                                'error'
+                                            );
+                                        }
+                                })())
+                            );
+                        if ('clear-availability-day' === r)
+                            return (
+                                o.preventDefault(),
+                                void (await (async function () {
+                                    if (!tt()) return;
+                                    const e = Fe();
+                                    if (0 !== e.length) {
+                                        if (
+                                            confirm(
+                                                `Eliminar ${e.length} horario${1 === e.length ? '' : 's'} de ${je(Ae)}?`
+                                            )
+                                        )
+                                            try {
+                                                (Oe(Ae, []),
+                                                    await et(),
+                                                    qe(Ae),
+                                                    Qe(Ae),
+                                                    w(
+                                                        'Horarios del dia eliminados',
+                                                        'success'
+                                                    ));
+                                            } catch (e) {
+                                                w(
+                                                    `No se pudo limpiar el dia: ${e.message}`,
+                                                    'error'
+                                                );
+                                            }
+                                    } else
+                                        w(
+                                            'No hay horarios que limpiar en este dia',
+                                            'warning'
+                                        );
+                                })())
+                            );
+                        if ('add-time-slot' === r)
+                            return (
+                                o.preventDefault(),
+                                void (await (async function () {
+                                    if (De)
+                                        return void w(
+                                            'Disponibilidad en solo lectura: gestionala desde Google Calendar.',
+                                            'warning'
+                                        );
+                                    if (!Ae)
+                                        return void w(
+                                            'Selecciona una fecha primero',
+                                            'warning'
+                                        );
+                                    const e =
+                                        document.getElementById(
+                                            'newSlotTime'
+                                        ).value;
+                                    if (e)
+                                        if (
+                                            (a[Ae] || (a[Ae] = []),
+                                            a[Ae].includes(e))
+                                        )
+                                            w(
+                                                'Este horario ya existe',
+                                                'warning'
+                                            );
+                                        else
+                                            try {
+                                                (a[Ae].push(e),
+                                                    await et(),
+                                                    Xe(Ae),
+                                                    Ze(),
+                                                    (document.getElementById(
+                                                        'newSlotTime'
+                                                    ).value = ''),
+                                                    w(
+                                                        'Horario agregado',
+                                                        'success'
+                                                    ));
+                                            } catch (e) {
+                                                w(
+                                                    `No se pudo guardar el horario: ${e.message}`,
+                                                    'error'
+                                                );
+                                            }
+                                    else w('Ingresa un horario', 'warning');
+                                })())
+                            );
+                        if ('remove-time-slot' === r)
+                            return (
+                                o.preventDefault(),
+                                void (await (async function (e, t) {
+                                    if (De)
+                                        w(
+                                            'Disponibilidad en solo lectura: gestionala desde Google Calendar.',
+                                            'warning'
+                                        );
+                                    else
+                                        try {
+                                            ((a[e] = (a[e] || []).filter(
+                                                (e) => e !== t
+                                            )),
+                                                await et(),
+                                                Xe(e),
+                                                Ze(),
+                                                w(
+                                                    'Horario eliminado',
+                                                    'success'
+                                                ));
+                                        } catch (e) {
+                                            w(
+                                                `No se pudo eliminar el horario: ${e.message}`,
+                                                'error'
+                                            );
+                                        }
+                                })(
+                                    decodeURIComponent(i.dataset.date || ''),
+                                    decodeURIComponent(i.dataset.time || '')
+                                ))
+                            );
+                        if ('approve-transfer' === r)
+                            return (
+                                o.preventDefault(),
+                                void (await (async function (e) {
+                                    if (
+                                        confirm(
+                                            '¿Aprobar el comprobante de transferencia de esta cita?'
+                                        )
+                                    )
+                                        if (e)
+                                            try {
+                                                (await h('appointments', {
+                                                    method: 'PATCH',
+                                                    body: {
+                                                        id: e,
+                                                        paymentStatus: 'paid',
+                                                        paymentPaidAt:
+                                                            new Date().toISOString(),
+                                                    },
+                                                }),
+                                                    await M(),
+                                                    Ce(),
+                                                    O(),
+                                                    w(
+                                                        'Transferencia aprobada',
+                                                        'success'
+                                                    ));
+                                            } catch (e) {
+                                                w(
+                                                    `No se pudo aprobar: ${e.message}`,
+                                                    'error'
+                                                );
+                                            }
+                                        else w('Id de cita invalido', 'error');
+                                })(Number(i.dataset.id || 0)))
+                            );
+                        if ('reject-transfer' === r)
+                            return (
+                                o.preventDefault(),
+                                void (await (async function (e) {
+                                    if (
+                                        confirm(
+                                            '¿Rechazar el comprobante de transferencia? La cita quedará como pago fallido.'
+                                        )
+                                    )
+                                        if (e)
+                                            try {
+                                                (await h('appointments', {
+                                                    method: 'PATCH',
+                                                    body: {
+                                                        id: e,
+                                                        paymentStatus: 'failed',
+                                                    },
+                                                }),
+                                                    await M(),
+                                                    Ce(),
+                                                    O(),
+                                                    w(
+                                                        'Transferencia rechazada',
+                                                        'warning'
+                                                    ));
+                                            } catch (e) {
+                                                w(
+                                                    `No se pudo rechazar: ${e.message}`,
+                                                    'error'
+                                                );
+                                            }
+                                        else w('Id de cita invalido', 'error');
+                                })(Number(i.dataset.id || 0)))
+                            );
+                        if ('cancel-appointment' === r)
+                            return (
+                                o.preventDefault(),
+                                void (await (async function (e) {
+                                    if (
+                                        confirm(
+                                            '¿Estas seguro de cancelar esta cita?'
+                                        )
+                                    )
+                                        if (e)
+                                            try {
+                                                (await h('appointments', {
+                                                    method: 'PATCH',
+                                                    body: {
+                                                        id: e,
+                                                        status: 'cancelled',
+                                                    },
+                                                }),
+                                                    await M(),
+                                                    Ce(),
+                                                    O(),
+                                                    w(
+                                                        'Cita cancelada correctamente',
+                                                        'success'
+                                                    ));
+                                            } catch (e) {
+                                                w(
+                                                    `No se pudo cancelar la cita: ${e.message}`,
+                                                    'error'
+                                                );
+                                            }
+                                        else w('Id de cita invalido', 'error');
+                                })(Number(i.dataset.id || 0)))
+                            );
+                        if ('mark-no-show' === r)
+                            return (
+                                o.preventDefault(),
+                                void (await (async function (e) {
+                                    if (
+                                        confirm(
+                                            'Marcar esta cita como "No asistio"?'
+                                        )
+                                    )
+                                        if (e)
+                                            try {
+                                                (await h('appointments', {
+                                                    method: 'PATCH',
+                                                    body: {
+                                                        id: e,
+                                                        status: 'no_show',
+                                                    },
+                                                }),
+                                                    await M(),
+                                                    Ce(),
+                                                    O(),
+                                                    w(
+                                                        'Cita marcada como no asistio',
+                                                        'success'
+                                                    ));
+                                            } catch (e) {
+                                                w(
+                                                    `No se pudo marcar no-show: ${e.message}`,
+                                                    'error'
+                                                );
+                                            }
+                                        else w('Id de cita invalido', 'error');
+                                })(Number(i.dataset.id || 0)))
+                            );
+                        'mark-contacted' === r &&
+                            (o.preventDefault(),
+                            await (async function (e, n = '') {
+                                let a = null;
+                                const o = Number(e);
+                                o > 0 &&
+                                    (a = t.find((e) => Number(e.id) === o));
+                                const i = n ? decodeURIComponent(n) : '';
+                                if (
+                                    (!a &&
+                                        i &&
+                                        (a = t.find((e) => e.fecha === i)),
+                                    a)
+                                )
+                                    try {
+                                        const e = a.id || Date.now();
+                                        (a.id || (a.id = e),
+                                            await h('callbacks', {
+                                                method: 'PATCH',
+                                                body: {
+                                                    id: Number(e),
+                                                    status: 'contactado',
+                                                },
+                                            }),
+                                            await M(),
+                                            U(),
+                                            O(),
+                                            w(
+                                                'Marcado como contactado',
+                                                'success'
+                                            ));
+                                    } catch (e) {
+                                        w(
+                                            `No se pudo actualizar callback: ${e.message}`,
+                                            'error'
+                                        );
+                                    }
+                                else w('Callback no encontrado', 'error');
+                            })(
+                                Number(i.dataset.callbackId || 0),
+                                i.dataset.callbackDate || ''
+                            ));
+                    } catch (e) {
+                        w(`Error ejecutando accion: ${e.message}`, 'error');
+                    }
+                } else i.closest('.toast')?.remove();
             });
-        const i = document.getElementById('searchAppointments');
-        i &&
-            i.addEventListener('input', () => {
-                pe();
-            });
-        const r = document.getElementById('appointmentSort');
-        r &&
-            r.addEventListener('change', () => {
-                !(function (e) {
-                    const t = ce(e),
-                        { sortSelect: n } = se();
-                    (n && (n.value = t), de(te, t), pe());
-                })(r.value || 'datetime_desc');
-            });
-        const s = document.getElementById('callbackFilter');
-        s && s.addEventListener('change', z);
-    })(),
+            const o = document.getElementById('appointmentFilter');
+            o &&
+                o.addEventListener('change', () => {
+                    Le();
+                });
+            const i = document.getElementById('searchAppointments');
+            i &&
+                i.addEventListener('input', () => {
+                    Le();
+                });
+            const r = document.getElementById('appointmentSort');
+            r &&
+                r.addEventListener('change', () => {
+                    !(function (e) {
+                        const t = we(e),
+                            { sortSelect: n } = ve();
+                        (n && (n.value = t), Ee(pe, t), Le());
+                    })(r.value || 'datetime_desc');
+                });
+            const s = document.getElementById('callbackFilter');
+            s && s.addEventListener('change', z);
+        })(),
         (function () {
-            const e = { sort: ce(T(te, ae)), density: le(T(ne, oe)) },
-                { sortSelect: t } = se();
-            (t && (t.value = e.sort), ue(e.density));
+            const e = { sort: we(T(pe, ge)), density: Se(T(fe, ye)) },
+                { sortSelect: t } = ve();
+            (t && (t.value = e.sort), ke(e.density));
         })());
     const o = document.getElementById('loginForm');
-    (o && o.addEventListener('submit', it),
-        Ge().forEach((e) => {
+    (o && o.addEventListener('submit', ht),
+        at().forEach((e) => {
             e.addEventListener('click', async (t) => {
                 (t.preventDefault(),
-                    await nt(e.dataset.section || 'dashboard'));
+                    await ft(e.dataset.section || 'dashboard'));
             });
         }),
         document
@@ -2519,21 +2618,21 @@ document.addEventListener('DOMContentLoaded', async () => {
             ?.addEventListener('click', () => {
                 const e = document.getElementById('adminSidebar'),
                     t = e?.classList.contains('is-open');
-                et(!t);
+                mt(!t);
             }),
         document
             .getElementById('adminMenuClose')
-            ?.addEventListener('click', () => tt({ restoreFocus: !0 })),
+            ?.addEventListener('click', () => pt({ restoreFocus: !0 })),
         document
             .getElementById('adminSidebarBackdrop')
-            ?.addEventListener('click', () => tt({ restoreFocus: !0 })),
+            ?.addEventListener('click', () => pt({ restoreFocus: !0 })),
         window.addEventListener('keydown', (e) => {
             (!(function (e) {
                 if ('Tab' !== e.key) return;
-                if (!Ve() || !Ke()) return;
+                if (!rt() || !st()) return;
                 const t = document.getElementById('adminSidebar');
                 if (!t) return;
-                const n = Qe();
+                const n = dt();
                 if (0 === n.length) return (e.preventDefault(), void t.focus());
                 const a = n[0],
                     o = n[n.length - 1],
@@ -2546,16 +2645,16 @@ document.addEventListener('DOMContentLoaded', async () => {
                           (e.preventDefault(), a.focus())
                     : (e.preventDefault(), (e.shiftKey ? o : a).focus());
             })(e),
-                'Escape' === e.key && tt({ restoreFocus: !0 }));
+                'Escape' === e.key && pt({ restoreFocus: !0 }));
         }),
         window.addEventListener('resize', () => {
-            (Ve() || tt(), Xe(Ke()));
+            (rt() || pt(), ut(st()));
         }),
         window.addEventListener('hashchange', async () => {
             const e = document.getElementById('adminDashboard');
             e &&
                 !e.classList.contains('is-hidden') &&
-                (await nt(We(), {
+                (await ft(ot(), {
                     refresh: !1,
                     updateHash: !1,
                     focus: !1,
@@ -2598,7 +2697,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                         (await h('import', { method: 'POST', body: a }),
                             await M());
                         const o = document.querySelector('.nav-item.active');
-                        (await at(o?.dataset.section || 'dashboard'),
+                        (await gt(o?.dataset.section || 'dashboard'),
                             w(
                                 `Datos importados: ${a.appointments.length} citas`,
                                 'success'
@@ -2611,14 +2710,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         window.addEventListener('online', async () => {
             (w('Conexion restaurada. Actualizando datos...', 'success'),
                 await M(),
-                await at(Je()));
+                await gt(it()));
         }),
-        Xe(!1),
+        ut(!1),
         await (async function () {
             if (!navigator.onLine && T('appointments', null))
                 return (
                     w('Modo offline: mostrando datos locales', 'info'),
-                    void (await ot())
+                    void (await yt())
                 );
             (await (async function () {
                 try {
@@ -2630,11 +2729,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                     return (w('No se pudo verificar la sesion', 'warning'), !1);
                 }
             })())
-                ? await ot()
+                ? await yt()
                 : (function () {
                       const e = document.getElementById('loginScreen'),
                           t = document.getElementById('adminDashboard');
-                      (tt(),
+                      (pt(),
                           e && e.classList.remove('is-hidden'),
                           t && t.classList.add('is-hidden'));
                   })();

--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
             defer
         ></script>
         <script
-            src="script.js?v=figo-20260222-slotservicefix1"
+            src="script.js?v=figo-20260226-themefix1"
             type="module"
         ></script>
     </head>

--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,7 @@ import {
     debugLog,
 } from './utils.js';
 import { initActionRouterEngine } from './router.js';
-import { initThemeMode } from './theme.js';
+import { initThemeMode, setThemeMode } from './theme.js';
 import { changeLanguage, initEnglishBundleWarmup } from './i18n.js';
 import { state } from './state.js';
 import { bootstrapConsent, showConsentBanner, initGA4 } from './cookies.js';
@@ -76,6 +76,34 @@ function loadSuccessModalRuntime() {
         successModalRuntimePromise = import('./success-modal.js');
     }
     return successModalRuntimePromise;
+}
+
+let themeButtonFallbackBridgeBound = false;
+
+function initThemeButtonFallbackBridge() {
+    if (themeButtonFallbackBridgeBound) {
+        return;
+    }
+    themeButtonFallbackBridgeBound = true;
+
+    document.addEventListener('click', (event) => {
+        const target = event.target instanceof Element ? event.target : null;
+        if (!target) return;
+
+        const button = target.closest('.theme-btn[data-theme-mode]');
+        if (!button) return;
+
+        const mode =
+            button.getAttribute('data-theme-mode') ||
+            button.getAttribute('data-value') ||
+            'system';
+
+        // Theme buttons should work even if the deferred action-router engine
+        // has not finished loading yet.
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        setThemeMode(mode);
+    });
 }
 
 import { loadFeatureFlags, isFeatureEnabled } from './features.js';
@@ -516,6 +544,7 @@ document.addEventListener('DOMContentLoaded', function () {
     disablePlaceholderExternalLinks();
     bootstrapConsent();
     initChatActionFallbackBridge();
+    initThemeButtonFallbackBridge();
     initActionRouterEngine();
     initDeferredStylesheetLoading();
     initThemeMode();

--- a/script.js
+++ b/script.js
@@ -4,8 +4,8 @@ const e = localStorage.getItem('language'),
         : 'es';
 let n = e || t,
     o = localStorage.getItem('themeMode') || 'system',
-    i = null,
-    a = { active: !1, completed: !1, startedAt: 0, service: '', doctor: '' },
+    a = null,
+    i = { active: !1, completed: !1, startedAt: 0, service: '', doctor: '' },
     r = 0;
 const c = new Map();
 let s = [],
@@ -24,12 +24,12 @@ function p() {
     return n;
 }
 function f() {
-    return i;
+    return a;
 }
-function w(e) {
-    i = e;
+function y(e) {
+    a = e;
 }
-function y() {
+function w() {
     return s;
 }
 function b(e) {
@@ -86,12 +86,12 @@ function I() {
         return [];
     }
 }
-function B(e) {
+function D(e) {
     try {
         localStorage.setItem('chatHistory', JSON.stringify(e));
     } catch {}
 }
-const D = {
+const B = {
         currentLang: [
             p,
             function (e) {
@@ -106,16 +106,16 @@ const D = {
                 o = e;
             },
         ],
-        currentAppointment: [f, w],
+        currentAppointment: [f, y],
         checkoutSession: [
             function () {
-                return a;
+                return i;
             },
             function (e) {
-                a = e;
+                i = e;
             },
         ],
-        reviewsCache: [y, b],
+        reviewsCache: [w, b],
         chatbotOpen: [j, L],
         conversationContext: [_, T],
     },
@@ -125,15 +125,15 @@ const D = {
             get: (e, t, n) =>
                 'chatHistory' === t
                     ? I()
-                    : Object.prototype.hasOwnProperty.call(D, t)
-                      ? D[t][0]()
+                    : Object.prototype.hasOwnProperty.call(B, t)
+                      ? B[t][0]()
                       : Reflect.get(e, t, n),
             set: (e, t, n, o) =>
                 'chatHistory' === t
-                    ? (B(n), !0)
+                    ? (D(n), !0)
                     : 'bookedSlotsCache' !== t &&
-                      (Object.prototype.hasOwnProperty.call(D, t)
-                          ? (D[t][1](n), !0)
+                      (Object.prototype.hasOwnProperty.call(B, t)
+                          ? (B[t][1](n), !0)
                           : Reflect.set(e, t, n, o)),
         }
     ),
@@ -181,9 +181,9 @@ function V(e, t = 'info', n = '') {
         (o.id = 'toastContainer'),
         (o.className = 'toast-container'),
         document.body.appendChild(o));
-    const i = document.createElement('div');
-    i.className = `toast ${t}`;
-    const a = {
+    const a = document.createElement('div');
+    a.className = `toast ${t}`;
+    const i = {
             success: n || 'Exito',
             error: n || 'Error',
             warning: n || 'Advertencia',
@@ -194,12 +194,12 @@ function V(e, t = 'info', n = '') {
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
             .replace(/"/g, '&quot;');
-    ((i.innerHTML = `\n        <i class="fas ${{ success: 'fa-check-circle', error: 'fa-times-circle', warning: 'fa-exclamation-circle', info: 'fa-info-circle' }[t]} toast-icon"></i>\n        <div class="toast-content">\n            <div class="toast-title">${a[t]}</div>\n            <div class="toast-message">${r}</div>\n        </div>\n        <button type="button" class="toast-close" data-action="toast-close">\n            <i class="fas fa-times"></i>\n        </button>\n        <div class="toast-progress"></div>\n    `),
-        o.appendChild(i),
+    ((a.innerHTML = `\n        <i class="fas ${{ success: 'fa-check-circle', error: 'fa-times-circle', warning: 'fa-exclamation-circle', info: 'fa-info-circle' }[t]} toast-icon"></i>\n        <div class="toast-content">\n            <div class="toast-title">${i[t]}</div>\n            <div class="toast-message">${r}</div>\n        </div>\n        <button type="button" class="toast-close" data-action="toast-close">\n            <i class="fas fa-times"></i>\n        </button>\n        <div class="toast-progress"></div>\n    `),
+        o.appendChild(a),
         setTimeout(() => {
-            i.parentElement &&
-                ((i.style.animation = 'slideIn 0.3s ease reverse'),
-                setTimeout(() => i.remove(), 300));
+            a.parentElement &&
+                ((a.style.animation = 'slideIn 0.3s ease reverse'),
+                setTimeout(() => a.remove(), 300));
         }, 5e3));
 }
 function G(e, t) {
@@ -221,20 +221,20 @@ function Q(e) {
         cacheKey: t,
         src: n,
         scriptDataAttribute: o,
-        resolveModule: i,
-        isModuleReady: a = (e) => !!e,
+        resolveModule: a,
+        isModuleReady: i = (e) => !!e,
         onModuleReady: r,
         missingApiError: c = 'Deferred module loaded without expected API',
         loadError: s = 'No se pudo cargar el modulo diferido',
         logLabel: l = '',
     } = e || {};
-    if (!t || !n || !o || 'function' != typeof i)
+    if (!t || !n || !o || 'function' != typeof a)
         return Promise.reject(
             new Error('Invalid deferred module configuration')
         );
     const u = () => {
-            const e = i();
-            return a(e) ? ('function' == typeof r && r(e), e) : null;
+            const e = a();
+            return i(e) ? ('function' == typeof r && r(e), e) : null;
         },
         d = u();
     if (d) return Promise.resolve(d);
@@ -265,8 +265,8 @@ function Y(e, t = {}) {
     const {
         idleTimeout: n = 2e3,
         fallbackDelay: o = 1200,
-        skipOnConstrained: i = !0,
-        constrainedDelay: a = o,
+        skipOnConstrained: a = !0,
+        constrainedDelay: i = o,
     } = t;
     return (function () {
         const e =
@@ -279,15 +279,15 @@ function Y(e, t = {}) {
                 !/(^|[^0-9])2g/.test(String(e.effectiveType || '')))
         );
     })()
-        ? !i && (setTimeout(e, a), !0)
+        ? !a && (setTimeout(e, i), !0)
         : ('function' == typeof window.requestIdleCallback
               ? window.requestIdleCallback(e, { timeout: n })
               : setTimeout(e, o),
           !0);
 }
 function X(e, t, n, o = !0) {
-    const i = document.querySelector(e);
-    return !!i && (i.addEventListener(t, n, { once: !0, passive: o }), !0);
+    const a = document.querySelector(e);
+    return !!a && (a.addEventListener(t, n, { once: !0, passive: o }), !0);
 }
 function Z(e) {
     let t = !1;
@@ -314,17 +314,17 @@ function ee(e, t = {}) {
     };
 }
 function te(e, t, n = {}) {
-    const { threshold: o = 0.05, rootMargin: i = '0px', onNoObserver: a } = n;
+    const { threshold: o = 0.05, rootMargin: a = '0px', onNoObserver: i } = n;
     if (!e) return !1;
     if (!('IntersectionObserver' in window))
-        return ('function' == typeof a && a(), !1);
+        return ('function' == typeof i && i(), !1);
     const r = new IntersectionObserver(
         (e) => {
             e.forEach((e) => {
                 e.isIntersecting && (t(e), r.disconnect());
             });
         },
-        { threshold: o, rootMargin: i }
+        { threshold: o, rootMargin: a }
     );
     return (r.observe(e), !0);
 }
@@ -338,14 +338,14 @@ function oe(e, t, n) {
         if ('function' == typeof n) return n(e);
     });
 }
-const ie = $('/js/engines/ui-bundle.js'),
-    ae = window.matchMedia
+const ae = $('/js/engines/ui-bundle.js'),
+    ie = window.matchMedia
         ? window.matchMedia('(prefers-color-scheme: dark)')
         : null;
 function re() {
     return Q({
         cacheKey: 'theme-engine',
-        src: ie,
+        src: ae,
         scriptDataAttribute: 'data-ui-bundle',
         resolveModule: () => window.Piel && window.Piel.ThemeEngine,
         isModuleReady: (e) => !(!e || 'function' != typeof e.init),
@@ -357,7 +357,7 @@ function re() {
                 },
                 themeStorageKey: 'themeMode',
                 validThemeModes: Array.from(W),
-                getSystemThemeQuery: () => ae,
+                getSystemThemeQuery: () => ie,
             }),
         missingApiError: 'theme-engine loaded without API',
         loadError: 'No se pudo cargar theme-engine.js',
@@ -409,15 +409,15 @@ async function he(e, t = {}) {
         Object.entries(t.query).forEach(([e, t]) => {
             null != t && '' !== t && o.set(e, String(t));
         });
-    const i = `${N}?${o.toString()}`,
-        a = {
+    const a = `${N}?${o.toString()}`,
+        i = {
             method: n,
             credentials: 'same-origin',
             headers: { Accept: 'application/json' },
         };
     void 0 !== t.body &&
-        ((a.headers['Content-Type'] = 'application/json'),
-        (a.body = JSON.stringify(t.body)));
+        ((i.headers['Content-Type'] = 'application/json'),
+        (i.body = JSON.stringify(t.body)));
     const c = Number.isFinite(t.timeoutMs)
             ? Math.max(1500, Number(t.timeoutMs))
             : 9e3,
@@ -429,8 +429,8 @@ async function he(e, t = {}) {
         l = !0 !== t.silentSlowNotice,
         u = new Set([408, 425, 429, 500, 502, 503, 504]);
     function d(e, t = 0, n = !1, o = '') {
-        const i = new Error(e);
-        return ((i.status = t), (i.retryable = n), (i.code = o), i);
+        const a = new Error(e);
+        return ((a.status = t), (a.retryable = n), (a.code = o), a);
     }
     let g = null;
     for (let e = 0; e <= s; e += 1) {
@@ -450,7 +450,7 @@ async function he(e, t = {}) {
                     ));
             }, 1200));
         try {
-            const e = await fetch(i, { ...a, signal: t.signal }),
+            const e = await fetch(a, { ...i, signal: t.signal }),
                 n = await e.text();
             let o = {};
             try {
@@ -532,10 +532,10 @@ function pe() {
 async function fe() {
     return oe(pe, (e) => e.loadPaymentConfig());
 }
-async function we() {
+async function ye() {
     return oe(pe, (e) => e.loadStripeSdk());
 }
-async function ye(e) {
+async function we(e) {
     return oe(pe, (t) => t.createPaymentIntent(e));
 }
 async function be(e) {
@@ -600,29 +600,29 @@ async function Pe(e) {
                 (e.style.display = 'none'),
                 document.body.appendChild(e),
                 new Promise((o) => {
-                    let i = null;
-                    const a = () => {
+                    let a = null;
+                    const i = () => {
                         try {
-                            null !== i &&
+                            null !== a &&
                                 window.turnstile &&
                                 'function' == typeof window.turnstile.remove &&
-                                window.turnstile.remove(i);
+                                window.turnstile.remove(a);
                         } catch (e) {}
                         e.remove();
                     };
                     try {
-                        i = window.turnstile.render(e, {
+                        a = window.turnstile.render(e, {
                             sitekey: n,
                             action: t,
                             callback: (e) => {
-                                (a(), o(e || null));
+                                (i(), o(e || null));
                             },
                             'error-callback': () => {
-                                (a(), o(null));
+                                (i(), o(null));
                             },
                         });
                     } catch (e) {
-                        (a(), o(null));
+                        (i(), o(null));
                     }
                 })
             );
@@ -690,12 +690,12 @@ async function Te(e) {
 async function Ie(e) {
     return ne(Ce, (t) => t.createReviewRecord(e));
 }
-async function Be(e, t = {}) {
+async function De(e, t = {}) {
     return ne(Ce, (n) => n.uploadTransferProof(e, t));
 }
-let De = null;
+let Be = null;
 function Re(e = {}) {
-    return (De || (De = import('./js/chunks/engagement-CxyxLpwi.js')), De).then(
+    return (Be || (Be = import('./js/chunks/engagement-CxyxLpwi.js')), Be).then(
         (t) => t.loadPublicReviews(e)
     );
 }
@@ -747,11 +747,11 @@ function We(e = {}) {
     o &&
         !Object.prototype.hasOwnProperty.call(t, 'ab_variant') &&
         (t.ab_variant = o);
-    const i = Ke(n.source, '');
+    const a = Ke(n.source, '');
     return (
-        i &&
+        a &&
             !Object.prototype.hasOwnProperty.call(t, 'source') &&
-            (t.source = i),
+            (t.source = a),
         t
     );
 }
@@ -785,7 +785,7 @@ function ze(e, t = {}) {
                   t)
                 : t;
         })(We(t)),
-        i = [
+        a = [
             n,
             o.step || '',
             o.payment_method || '',
@@ -793,9 +793,9 @@ function ze(e, t = {}) {
             o.reason || '',
             o.source || '',
         ].join('|'),
-        a = Date.now();
-    if (a - (Ue.get(i) || 0) < 1200) return;
-    Ue.set(i, a);
+        i = Date.now();
+    if (i - (Ue.get(a) || 0) < 1200) return;
+    Ue.set(a, i);
     const r = JSON.stringify({ event: n, params: o });
     try {
         if (navigator.sendBeacon) {
@@ -886,20 +886,20 @@ async function et(e) {
                 };
             const n = new Array(t.length),
                 o = Math.max(1, Math.min(2, t.length));
-            let i = 0;
+            let a = 0;
             return (
                 await Promise.all(
                     Array.from({ length: o }, () =>
                         (async () => {
-                            for (; i < t.length; ) {
-                                const e = i;
-                                i += 1;
+                            for (; a < t.length; ) {
+                                const e = a;
+                                a += 1;
                                 const o = t[e],
-                                    a = await Be(o, { retries: 2 });
+                                    i = await De(o, { retries: 2 });
                                 n[e] = {
-                                    name: a.transferProofName || o.name || '',
-                                    url: a.transferProofUrl || '',
-                                    path: a.transferProofPath || '',
+                                    name: i.transferProofName || o.name || '',
+                                    url: i.transferProofUrl || '',
+                                    path: i.transferProofPath || '',
                                 };
                             }
                         })()
@@ -940,17 +940,17 @@ function tt() {
                     R.checkoutSession.active = !0 === e;
                 },
                 startCheckoutSession: ot,
-                setCheckoutStep: it,
-                completeCheckoutSession: at,
+                setCheckoutStep: at,
+                completeCheckoutSession: it,
                 maybeTrackCheckoutAbandon: rt,
                 loadPaymentConfig: fe,
-                loadStripeSdk: we,
-                createPaymentIntent: ye,
+                loadStripeSdk: ye,
+                createPaymentIntent: we,
                 verifyPaymentIntent: be,
                 buildAppointmentPayload: et,
                 stripTransientAppointmentFields: Ze,
                 createAppointmentRecord: _e,
-                uploadTransferProof: Be,
+                uploadTransferProof: De,
                 getCaptchaToken: Pe,
                 showSuccessModal: Xe,
                 showToast: V,
@@ -977,10 +977,10 @@ function nt() {
 function ot(e, t = {}) {
     oe(Fe, (n) => n.startCheckoutSession(e, t));
 }
-function it(e, t = {}) {
+function at(e, t = {}) {
     oe(Fe, (n) => n.setCheckoutStep(e, t));
 }
-function at(e) {
+function it(e) {
     oe(Fe, (t) => t.completeCheckoutSession(e));
 }
 function rt(e = 'unknown') {
@@ -1019,12 +1019,12 @@ function ut() {
         validateCasePhotoFiles: dt,
         markBookingViewed: Ge,
         startCheckoutSession: ot,
-        setCheckoutStep: it,
+        setCheckoutStep: at,
         trackEvent: $e,
         normalizeAnalyticsLabel: Ve,
         openPaymentModal: ht,
         debugLog: K,
-        setCurrentAppointment: w,
+        setCurrentAppointment: y,
     };
 }
 function dt(e) {
@@ -1046,8 +1046,8 @@ function dt(e) {
                 );
             const e = String(n.type || '').toLowerCase(),
                 o = t.has(e),
-                i = /\.(jpe?g|png|webp)$/i.test(String(n.name || ''));
-            if (!o && !i)
+                a = /\.(jpe?g|png|webp)$/i.test(String(n.name || ''));
+            if (!o && !a)
                 throw new Error(
                     'es' === R.currentLang
                         ? 'Solo se permiten imágenes JPG, PNG o WEBP.'
@@ -1113,12 +1113,12 @@ async function pt() {
     );
 }
 let ft = null;
-function wt() {
+function yt() {
     return (ft || (ft = import('./js/chunks/ui-C4GEqQxn.js')), ft);
 }
-let yt = null;
+let wt = null;
 function bt() {
-    return (yt || (yt = import('./js/chunks/engagement-CxyxLpwi.js')), yt);
+    return (wt || (wt = import('./js/chunks/engagement-CxyxLpwi.js')), wt);
 }
 let kt = null,
     vt = null;
@@ -1126,17 +1126,17 @@ function Pt() {
     return (vt || (vt = import('./js/chunks/reschedule-CiSqh0C5.js')), vt);
 }
 function Et(e) {
-    wt()
+    yt()
         .then((t) => t.toggleMobileMenu(e))
         .catch(() => {});
 }
 function Ct() {
-    wt()
+    yt()
         .then((e) => e.startWebVideo())
         .catch(() => {});
 }
 function St() {
-    wt()
+    yt()
         .then((e) => e.closeVideoModal())
         .catch(() => {});
 }
@@ -1170,7 +1170,7 @@ function Tt(e) {
         (await import('./js/chunks/shell-CjkQnRo5.js'))[e](...t);
 }
 const It = $('/js/engines/data-bundle.js?v=20260225-data-consolidation1');
-function Bt(e) {
+function Dt(e) {
     const t = document.getElementById('serviceSelect');
     if (t) {
         ((t.value = e),
@@ -1184,7 +1184,7 @@ function Bt(e) {
         }
     }
 }
-function Dt() {
+function Bt() {
     return Q({
         cacheKey: 'action-router-engine',
         src: It,
@@ -1214,7 +1214,7 @@ function Dt() {
                 minimizeChatbot: Tt('minimizeChatbot'),
                 startChatBooking: Tt('startChatBooking'),
                 handleChatDateSelect: Tt('handleChatDateSelect'),
-                selectService: Bt,
+                selectService: Dt,
             }),
         missingApiError: 'action-router-engine loaded without API',
         loadError: 'No se pudo cargar action-router-engine.js',
@@ -1252,8 +1252,9 @@ let Wt = null,
     Kt = null,
     zt = null,
     Ft = null,
-    $t = null;
-const Vt = import('./js/chunks/content-loader-BCpccN5h.js');
+    $t = null,
+    Vt = !1;
+const Gt = import('./js/chunks/content-loader-BCpccN5h.js');
 ((window.Piel = window.Piel || {}),
     (window.Piel.deployVersion =
         window.Piel.deployVersion ||
@@ -1286,12 +1287,12 @@ const Vt = import('./js/chunks/content-loader-BCpccN5h.js');
             }
             return '';
         })()));
-const Gt = 'pa_hero_variant_v1',
-    Ht = 'control',
-    Jt = 'focus_agenda',
-    Qt = [Ht, Jt],
-    Yt = {
-        [Ht]: {
+const Ht = 'pa_hero_variant_v1',
+    Jt = 'control',
+    Qt = 'focus_agenda',
+    Yt = [Jt, Qt],
+    Xt = {
+        [Jt]: {
             es: {
                 subtitle:
                     'Dermatologia especializada con tecnologia de vanguardia. Tratamientos personalizados para que tu piel luzca saludable y radiante.',
@@ -1303,7 +1304,7 @@ const Gt = 'pa_hero_variant_v1',
                 primaryCta: 'Book Consultation',
             },
         },
-        [Jt]: {
+        [Qt]: {
             es: {
                 subtitle:
                     'Agenda tu valoracion dermatologica en minutos, con atencion humana y seguimiento real.',
@@ -1316,9 +1317,9 @@ const Gt = 'pa_hero_variant_v1',
             },
         },
     };
-let Xt = null,
-    Zt = !1;
-function en() {
+let Zt = null,
+    en = !1;
+function tn() {
     return (function () {
         try {
             return !!window.matchMedia('(prefers-reduced-motion: reduce)')
@@ -1330,19 +1331,19 @@ function en() {
         ? 'auto'
         : 'smooth';
 }
-function tn() {
+function nn() {
     return (
-        Xt ||
-            (Xt =
+        Zt ||
+            (Zt =
                 (function () {
                     try {
                         const e = (function (e) {
                             const t = String(e || '')
                                 .trim()
                                 .toLowerCase();
-                            return Qt.includes(t) ? t : '';
-                        })(localStorage.getItem(Gt));
-                        if (Qt.includes(e)) return e;
+                            return Yt.includes(t) ? t : '';
+                        })(localStorage.getItem(Ht));
+                        if (Yt.includes(e)) return e;
                     } catch (e) {}
                     let e;
                     try {
@@ -1350,36 +1351,36 @@ function tn() {
                         (window.crypto &&
                         'function' == typeof window.crypto.getRandomValues
                             ? (window.crypto.getRandomValues(t),
-                              (e = t[0] % 2 == 0 ? Ht : Jt))
-                            : (e = Math.random() < 0.5 ? Ht : Jt),
-                            localStorage.setItem(Gt, e));
+                              (e = t[0] % 2 == 0 ? Jt : Qt))
+                            : (e = Math.random() < 0.5 ? Jt : Qt),
+                            localStorage.setItem(Ht, e));
                     } catch (t) {
-                        e = Math.random() < 0.5 ? Ht : Jt;
+                        e = Math.random() < 0.5 ? Jt : Qt;
                     }
-                    return e || Ht;
-                })() || Ht),
-        Xt
+                    return e || Jt;
+                })() || Jt),
+        Zt
     );
 }
-function nn() {
-    const e = tn(),
+function on() {
+    const e = nn(),
         t = 'en' === R.currentLang ? 'en' : 'es',
-        n = Yt[e] || Yt[Ht],
+        n = Xt[e] || Xt[Jt],
         o = n[t] || n.es,
-        i = document.querySelector('.hero-subtitle[data-i18n="hero_subtitle"]');
-    i && o.subtitle && (i.textContent = o.subtitle);
-    const a = document.querySelector(
+        a = document.querySelector('.hero-subtitle[data-i18n="hero_subtitle"]');
+    a && o.subtitle && (a.textContent = o.subtitle);
+    const i = document.querySelector(
         '.hero-actions .btn-primary[data-i18n="hero_cta_primary"]'
     );
-    (a && o.primaryCta && (a.textContent = o.primaryCta),
+    (i && o.primaryCta && (i.textContent = o.primaryCta),
         document.documentElement.setAttribute('data-hero-variant', e));
 }
 ((window.Piel.getExperimentContext = function () {
-    const e = tn();
+    const e = nn();
     return {
         heroVariant: e,
         source: `hero_${e}`,
-        checkoutEntry: e === Ht ? 'booking_form' : `booking_form_${e}`,
+        checkoutEntry: e === Jt ? 'booking_form' : `booking_form_${e}`,
     };
 }),
     (async function () {
@@ -1402,10 +1403,10 @@ function nn() {
     (window.Piel.isFeatureEnabled = function (e) {
         return !!Ot && Boolean(Ot[e]);
     }));
-const on = $('/styles-deferred.css?v=ui-20260221-deferred18-fullcssfix1');
-let an = null,
-    rn = !1;
-let cn = !1;
+const an = $('/styles-deferred.css?v=ui-20260221-deferred18-fullcssfix1');
+let rn = null,
+    cn = !1;
+let sn = !1;
 (document.addEventListener('DOMContentLoaded', function () {
     (document.querySelectorAll('a[href^="URL_"]').forEach((e) => {
         (e.removeAttribute('href'),
@@ -1413,15 +1414,15 @@ let cn = !1;
             e.classList.add('is-disabled-link'));
     }),
         Nt(),
-        cn ||
-            ((cn = !0),
+        sn ||
+            ((sn = !0),
             document.addEventListener('click', async function (e) {
                 const t = e.target instanceof Element ? e.target : null;
                 if (!t) return;
                 const n = t.closest('[data-action]');
                 if (!n) return;
                 const o = String(n.getAttribute('data-action') || '').trim(),
-                    i = n.getAttribute('data-value') || '';
+                    a = n.getAttribute('data-value') || '';
                 switch (o) {
                     case 'toggle-chatbot':
                         (e.preventDefault(),
@@ -1441,12 +1442,12 @@ let cn = !1;
                     case 'quick-message':
                         (e.preventDefault(),
                             e.stopImmediatePropagation(),
-                            (await Ut()).sendQuickMessage(i));
+                            (await Ut()).sendQuickMessage(a));
                         break;
                     case 'chat-booking':
                         (e.preventDefault(),
                             e.stopImmediatePropagation(),
-                            (await Ut()).handleChatBookingSelection(i));
+                            (await Ut()).handleChatBookingSelection(a));
                         break;
                     case 'start-booking':
                         (e.preventDefault(),
@@ -1471,11 +1472,11 @@ let cn = !1;
                                             t = n.offsetTop - e - 20;
                                         window.scrollTo({
                                             top: t,
-                                            behavior: en(),
+                                            behavior: tn(),
                                         });
                                     }
                                 }
-                            })(i));
+                            })(a));
                 }
             }),
             document.addEventListener('change', async function (e) {
@@ -1484,25 +1485,38 @@ let cn = !1;
                     t.closest('[data-action="chat-date-select"]') &&
                     (await Ut()).handleChatDateSelect(t.value);
             })),
+        Vt ||
+            ((Vt = !0),
+            document.addEventListener('click', (e) => {
+                const t = e.target instanceof Element ? e.target : null;
+                if (!t) return;
+                const n = t.closest('.theme-btn[data-theme-mode]');
+                if (!n) return;
+                const o =
+                    n.getAttribute('data-theme-mode') ||
+                    n.getAttribute('data-value') ||
+                    'system';
+                (e.preventDefault(), e.stopImmediatePropagation(), ce(o));
+            })),
         oe(
-            Dt,
+            Bt,
             () => {},
             (e) => {}
         ),
-        rn ||
+        cn ||
             'file:' === window.location.protocol ||
-            ((rn = !0),
+            ((cn = !0),
             Y(
                 () => {
                     (document.querySelector(
                         'link[data-deferred-stylesheet="true"], link[rel="stylesheet"][href*="styles-deferred.css"]'
                     )
                         ? Promise.resolve(!0)
-                        : an ||
-                          ((an = new Promise((e, t) => {
+                        : rn ||
+                          ((rn = new Promise((e, t) => {
                               const n = document.createElement('link');
                               ((n.rel = 'stylesheet'),
-                                  (n.href = on),
+                                  (n.href = an),
                                   (n.dataset.deferredStylesheet = 'true'),
                                   (n.onload = () => e(!0)),
                                   (n.onerror = () =>
@@ -1513,9 +1527,9 @@ let cn = !1;
                                       )),
                                   document.head.appendChild(n));
                           }).catch((e) => {
-                              throw ((an = null), e);
+                              throw ((rn = null), e);
                           })),
-                          an)
+                          rn)
                     ).catch(() => {});
                 },
                 {
@@ -1527,10 +1541,10 @@ let cn = !1;
             )),
         oe(re, (e) => e.initThemeMode()),
         ge(R.currentLang)
-            .then(() => nn())
-            .catch(() => nn()),
-        tn(),
+            .then(() => on())
+            .catch(() => on()),
         nn(),
+        on(),
         (function () {
             const e = (e, t) => {
                 const n = document.querySelector(e);
@@ -1539,7 +1553,7 @@ let cn = !1;
                     ((n.dataset.heroExperimentBound = 'true'),
                     n.addEventListener('click', () => {
                         $e('booking_step_completed', {
-                            source: `hero_${tn()}`,
+                            source: `hero_${nn()}`,
                             step: t,
                         });
                     }));
@@ -1552,18 +1566,18 @@ let cn = !1;
                     '.hero-actions .btn-secondary[data-i18n="hero_cta_secondary"]',
                     'hero_secondary_cta_click'
                 ),
-                Zt ||
-                    ((Zt = !0),
+                en ||
+                    ((en = !0),
                     $e('booking_step_completed', {
-                        source: `hero_${tn()}`,
+                        source: `hero_${nn()}`,
                         step: 'hero_variant_assigned',
                     })));
         })(),
-        document.addEventListener('piel:language-changed', nn),
+        document.addEventListener('piel:language-changed', on),
         oe(Nt, (e) => e.initGA4()),
         oe(Fe, (e) => e.initBookingFunnelObserver()),
         oe(Fe, (e) => e.initDeferredSectionPrefetch()),
-        Vt.then(({ loadDeferredContent: e }) => e())
+        Gt.then(({ loadDeferredContent: e }) => e())
             .catch(() => !1)
             .then(() => {
                 oe(Nt, (e) => e.initCookieBanner());
@@ -1701,15 +1715,15 @@ let cn = !1;
         if (!n) return;
         const o = n.closest('a[href^="#"]');
         if (!o) return;
-        const i = o.getAttribute('href');
-        if (!i || '#' === i) return;
-        const a = document.querySelector(i);
-        if (!a) return;
+        const a = o.getAttribute('href');
+        if (!a || '#' === a) return;
+        const i = document.querySelector(a);
+        if (!i) return;
         t.preventDefault();
         const r = e ? e.offsetHeight : 0,
-            c = a.offsetTop - r - 20;
-        ('#citas' === i && Ge(`cta_click_${tn()}`),
-            window.scrollTo({ top: c, behavior: en() }));
+            c = i.offsetTop - r - 20;
+        ('#citas' === a && Ge(`cta_click_${nn()}`),
+            window.scrollTo({ top: c, behavior: tn() }));
     }),
         document.addEventListener('click', function (e) {
             const t = e.target instanceof Element ? e.target : null;
@@ -1750,8 +1764,8 @@ let cn = !1;
                     if (e.isIntersecting) {
                         const n = e.target,
                             o = n.dataset.src,
-                            i = n.dataset.srcset;
-                        (i && (n.srcset = i),
+                            a = n.dataset.srcset;
+                        (a && (n.srcset = a),
                             (n.src = o),
                             n.classList.add('loaded'),
                             t.unobserve(n));
@@ -1779,7 +1793,7 @@ let cn = !1;
             } catch (e) {}
     }));
 export {
-    it as A,
+    at as A,
     ot as B,
     x as C,
     U as D,
@@ -1787,7 +1801,7 @@ export {
     je as F,
     te as G,
     b as H,
-    y as I,
+    w as I,
     Ie as J,
     Te as K,
     z as L,
@@ -1803,7 +1817,7 @@ export {
     q as f,
     j as g,
     O as h,
-    B as i,
+    D as i,
     I as j,
     f as k,
     Q as l,
@@ -1811,7 +1825,7 @@ export {
     _ as n,
     K as o,
     R as p,
-    w as q,
+    y as q,
     oe as r,
     V as s,
     $e as t,
@@ -1820,5 +1834,5 @@ export {
     ne as w,
     Pe as x,
     _e as y,
-    at as z,
+    it as z,
 };

--- a/src/apps/admin/index.js
+++ b/src/apps/admin/index.js
@@ -17,6 +17,7 @@ import {
 } from './modules/callbacks.js';
 import { loadReviews } from './modules/reviews.js';
 import { initPushNotifications } from './modules/push.js';
+import { initAdminThemeMode, setAdminThemeMode } from './modules/theme.js';
 import {
     loadAppointments,
     filterAppointments,
@@ -560,6 +561,12 @@ function attachGlobalListeners() {
             return;
         }
 
+        if (action === 'set-admin-theme') {
+            event.preventDefault();
+            setAdminThemeMode(actionEl.dataset.themeMode || 'system');
+            return;
+        }
+
         try {
             if (action === 'export-csv') {
                 event.preventDefault();
@@ -686,6 +693,7 @@ function attachGlobalListeners() {
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
+    initAdminThemeMode();
     attachGlobalListeners();
     initAppointmentsToolbarPreferences();
 

--- a/src/apps/admin/modules/theme.js
+++ b/src/apps/admin/modules/theme.js
@@ -1,0 +1,135 @@
+const ADMIN_THEME_STORAGE_KEY = 'themeMode';
+const VALID_THEME_MODES = new Set(['light', 'dark', 'system']);
+
+let currentThemeMode = 'system';
+let systemThemeQuery = null;
+let systemThemeListenerBound = false;
+let transitionTimer = null;
+
+function getSystemThemeQuery() {
+    if (!systemThemeQuery && typeof window.matchMedia === 'function') {
+        systemThemeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    }
+    return systemThemeQuery;
+}
+
+function isValidThemeMode(mode) {
+    return VALID_THEME_MODES.has(String(mode || '').trim());
+}
+
+function resolveTheme(mode) {
+    if (mode !== 'system') {
+        return mode;
+    }
+    return getSystemThemeQuery()?.matches ? 'dark' : 'light';
+}
+
+function readStoredThemeMode() {
+    try {
+        const stored =
+            localStorage.getItem(ADMIN_THEME_STORAGE_KEY) || 'system';
+        return isValidThemeMode(stored) ? stored : 'system';
+    } catch (_error) {
+        return 'system';
+    }
+}
+
+function persistThemeMode(mode) {
+    try {
+        localStorage.setItem(ADMIN_THEME_STORAGE_KEY, mode);
+    } catch (_error) {
+        // no-op
+    }
+}
+
+function applyThemeAttributes(mode) {
+    const root = document.documentElement;
+    if (!root) return;
+
+    const resolvedTheme = resolveTheme(mode);
+    root.setAttribute('data-theme-mode', mode);
+    root.setAttribute('data-theme', resolvedTheme);
+}
+
+function updateThemeButtons() {
+    document
+        .querySelectorAll('.admin-theme-btn[data-theme-mode]')
+        .forEach((btn) => {
+            const isActive = btn.dataset.themeMode === currentThemeMode;
+            btn.classList.toggle('is-active', isActive);
+            btn.setAttribute('aria-pressed', String(isActive));
+        });
+}
+
+function animateThemeTransition() {
+    if (!document.body) return;
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches)
+        return;
+
+    if (transitionTimer) {
+        clearTimeout(transitionTimer);
+    }
+
+    document.body.classList.remove('theme-transition');
+    void document.body.offsetWidth;
+    document.body.classList.add('theme-transition');
+
+    transitionTimer = setTimeout(() => {
+        document.body?.classList.remove('theme-transition');
+    }, 220);
+}
+
+function applyThemeMode(mode, { persist = false, animate = false } = {}) {
+    const nextMode = isValidThemeMode(mode) ? mode : 'system';
+    currentThemeMode = nextMode;
+
+    if (persist) {
+        persistThemeMode(nextMode);
+    }
+
+    if (animate) {
+        animateThemeTransition();
+    }
+
+    applyThemeAttributes(nextMode);
+    updateThemeButtons();
+}
+
+function handleSystemThemeChange() {
+    if (currentThemeMode !== 'system') {
+        return;
+    }
+    applyThemeAttributes('system');
+    updateThemeButtons();
+}
+
+function bindSystemThemeListener() {
+    if (systemThemeListenerBound) return;
+    const query = getSystemThemeQuery();
+    if (!query) return;
+
+    if (typeof query.addEventListener === 'function') {
+        query.addEventListener('change', handleSystemThemeChange);
+        systemThemeListenerBound = true;
+        return;
+    }
+
+    if (typeof query.addListener === 'function') {
+        query.addListener(handleSystemThemeChange);
+        systemThemeListenerBound = true;
+    }
+}
+
+export function initAdminThemeMode() {
+    currentThemeMode = readStoredThemeMode();
+    applyThemeMode(currentThemeMode, { persist: false, animate: false });
+    bindSystemThemeListener();
+}
+
+export function setAdminThemeMode(mode) {
+    applyThemeMode(mode, { persist: true, animate: true });
+}
+
+export function getAdminThemeMode() {
+    return currentThemeMode;
+}

--- a/telemedicina.html
+++ b/telemedicina.html
@@ -2706,7 +2706,7 @@
             defer
         ></script>
         <script
-            src="script.js?v=figo-20260222-slotservicefix1"
+            src="script.js?v=figo-20260226-themefix1"
             type="module"
         ></script>
         <script src="js/telemedicina-init.js" defer></script>

--- a/templates/partials/head-links.html
+++ b/templates/partials/head-links.html
@@ -58,7 +58,7 @@
             defer
         ></script>
         <script
-            src="script.js?v=figo-20260222-slotservicefix1"
+            src="script.js?v=figo-20260226-themefix1"
             type="module"
         ></script>
     </head>

--- a/templates/partials/tele-body-cookie.html
+++ b/templates/partials/tele-body-cookie.html
@@ -40,7 +40,7 @@
             defer
         ></script>
         <script
-            src="script.js?v=figo-20260222-slotservicefix1"
+            src="script.js?v=figo-20260226-themefix1"
             type="module"
         ></script>
         <script src="js/telemedicina-init.js" defer></script>

--- a/tests/admin.spec.js
+++ b/tests/admin.spec.js
@@ -2,13 +2,93 @@
 const { test, expect } = require('@playwright/test');
 const { skipIfPhpRuntimeMissing } = require('./helpers/php-backend');
 
-test.describe('Panel de administración', () => {
-    test('página admin carga correctamente', async ({ page }) => {
+function jsonResponse(route, payload, status = 200) {
+    return route.fulfill({
+        status,
+        contentType: 'application/json; charset=utf-8',
+        body: JSON.stringify(payload),
+    });
+}
+
+async function setupAuthenticatedAdminMocks(page) {
+    const baseData = {
+        appointments: [],
+        callbacks: [],
+        reviews: [],
+        availability: {},
+        availabilityMeta: {
+            source: 'store',
+            mode: 'live',
+            timezone: 'America/Guayaquil',
+            calendarConfigured: true,
+            calendarReachable: true,
+            generatedAt: new Date().toISOString(),
+        },
+    };
+
+    await page.route(/\/admin-auth\.php(\?.*)?$/i, async (route) =>
+        jsonResponse(route, {
+            ok: true,
+            authenticated: true,
+            csrfToken: 'csrf_test_token',
+        })
+    );
+
+    await page.route(/\/api\.php(\?.*)?$/i, async (route) => {
+        const url = new URL(route.request().url());
+        const resource = url.searchParams.get('resource') || '';
+
+        if (resource === 'data') {
+            return jsonResponse(route, { ok: true, data: baseData });
+        }
+
+        if (resource === 'funnel-metrics') {
+            return jsonResponse(route, {
+                ok: true,
+                data: {
+                    summary: {
+                        viewBooking: 0,
+                        startCheckout: 0,
+                        bookingConfirmed: 0,
+                        checkoutAbandon: 0,
+                        startRatePct: 0,
+                        confirmedRatePct: 0,
+                        abandonRatePct: 0,
+                    },
+                    checkoutAbandonByStep: [],
+                    checkoutEntryBreakdown: [],
+                    paymentMethodBreakdown: [],
+                    bookingStepBreakdown: [],
+                    sourceBreakdown: [],
+                    abandonReasonBreakdown: [],
+                    errorCodeBreakdown: [],
+                },
+            });
+        }
+
+        if (resource === 'availability') {
+            return jsonResponse(route, {
+                ok: true,
+                data: baseData.availability,
+                meta: baseData.availabilityMeta,
+            });
+        }
+
+        if (resource === 'monitoring-config') {
+            return jsonResponse(route, { ok: true, data: {} });
+        }
+
+        return jsonResponse(route, { ok: true, data: {} });
+    });
+}
+
+test.describe('Panel de administracion', () => {
+    test('pagina admin carga correctamente', async ({ page }) => {
         await page.goto('/admin.html');
-        await expect(page).toHaveTitle(/Admin|Piel en Armonía/);
+        await expect(page).toHaveTitle(/Admin|Piel en Armonia/);
     });
 
-    test('formulario de login está visible', async ({ page }) => {
+    test('formulario de login esta visible', async ({ page }) => {
         await page.goto('/admin.html');
         const loginForm = page
             .locator('#loginForm, form, [class*="login"]')
@@ -16,7 +96,47 @@ test.describe('Panel de administración', () => {
         await expect(loginForm).toBeVisible();
     });
 
-    test('login con contraseña vacía no funciona', async ({ page }) => {
+    test('tema claro/oscuro funciona en login y persiste tras recarga', async ({
+        page,
+    }) => {
+        await page.goto('/admin.html');
+
+        const darkThemeBtn = page
+            .locator(
+                '.login-theme-bar .admin-theme-btn[data-theme-mode="dark"]'
+            )
+            .first();
+        await expect(darkThemeBtn).toBeVisible();
+        await darkThemeBtn.click();
+
+        await expect
+            .poll(async () =>
+                page.evaluate(() => ({
+                    mode: document.documentElement.getAttribute(
+                        'data-theme-mode'
+                    ),
+                    theme: document.documentElement.getAttribute('data-theme'),
+                    stored: localStorage.getItem('themeMode'),
+                }))
+            )
+            .toEqual({
+                mode: 'dark',
+                theme: 'dark',
+                stored: 'dark',
+            });
+
+        await page.reload();
+        await expect(page.locator('#loginForm')).toBeVisible();
+        await expect
+            .poll(async () =>
+                page.evaluate(() =>
+                    document.documentElement.getAttribute('data-theme')
+                )
+            )
+            .toBe('dark');
+    });
+
+    test('login con contrasena vacia no funciona', async ({ page }) => {
         await page.goto('/admin.html');
         const passwordInput = page.locator('input[type="password"]').first();
         const loginBtn = page
@@ -27,12 +147,11 @@ test.describe('Panel de administración', () => {
             await passwordInput.fill('');
             await loginBtn.click();
             await page.waitForTimeout(1000);
-            // No debería mostrar el dashboard; login debería seguir visible
             await expect(passwordInput).toBeVisible();
         }
     });
 
-    test('login con contraseña incorrecta muestra error', async ({ page }) => {
+    test('login con contrasena incorrecta muestra error', async ({ page }) => {
         await page.goto('/admin.html');
         const passwordInput = page.locator('input[type="password"]').first();
         const loginBtn = page
@@ -40,11 +159,10 @@ test.describe('Panel de administración', () => {
             .first();
 
         if ((await passwordInput.isVisible()) && (await loginBtn.isVisible())) {
-            await passwordInput.fill('contraseña_incorrecta_test');
+            await passwordInput.fill('contrasena_incorrecta_test');
             await loginBtn.click();
             await page.waitForTimeout(2000);
 
-            // Debería mostrar algún tipo de error
             const errorMsg = page
                 .locator('[class*="error"], [class*="alert"], .toast')
                 .first();
@@ -65,6 +183,58 @@ test.describe('Panel de administración', () => {
         await expect(page.locator('#funnelAbandonReasonList')).toHaveCount(1);
         await expect(page.locator('#funnelStepList')).toHaveCount(1);
         await expect(page.locator('#funnelErrorCodeList')).toHaveCount(1);
+    });
+
+    test('tema tambien funciona en dashboard autenticado', async ({ page }) => {
+        await setupAuthenticatedAdminMocks(page);
+        await page.goto('/admin.html');
+
+        await expect(page.locator('#adminDashboard')).toBeVisible();
+        const headerDarkBtn = page
+            .locator(
+                '.admin-theme-switcher-header .admin-theme-btn[data-theme-mode="dark"]'
+            )
+            .first();
+        const headerLightBtn = page
+            .locator(
+                '.admin-theme-switcher-header .admin-theme-btn[data-theme-mode="light"]'
+            )
+            .first();
+
+        await expect(headerDarkBtn).toBeVisible();
+        await headerDarkBtn.click();
+
+        await expect
+            .poll(async () =>
+                page.evaluate(() => ({
+                    mode: document.documentElement.getAttribute(
+                        'data-theme-mode'
+                    ),
+                    theme: document.documentElement.getAttribute('data-theme'),
+                }))
+            )
+            .toEqual({ mode: 'dark', theme: 'dark' });
+
+        await page.reload();
+        await expect(page.locator('#adminDashboard')).toBeVisible();
+        await expect(headerDarkBtn).toHaveClass(/is-active/);
+        await expect
+            .poll(async () =>
+                page.evaluate(() => ({
+                    theme: document.documentElement.getAttribute('data-theme'),
+                    stored: localStorage.getItem('themeMode'),
+                }))
+            )
+            .toEqual({ theme: 'dark', stored: 'dark' });
+
+        await headerLightBtn.click();
+        await expect
+            .poll(async () =>
+                page.evaluate(() =>
+                    document.documentElement.getAttribute('data-theme')
+                )
+            )
+            .toBe('light');
     });
 
     test.describe('API de administracion (requiere PHP)', () => {

--- a/tests/homepage.spec.js
+++ b/tests/homepage.spec.js
@@ -69,6 +69,63 @@ test.describe('Homepage', () => {
         expect(hasValidThemeState).toBeTruthy();
     });
 
+    test('sistema de temas cambia a oscuro y persiste tras recarga', async ({
+        page,
+    }) => {
+        const darkBtn = page
+            .locator('.theme-btn[data-theme-mode="dark"]')
+            .first();
+        const lightBtn = page
+            .locator('.theme-btn[data-theme-mode="light"]')
+            .first();
+
+        await expect(darkBtn).toBeVisible();
+        await darkBtn.click();
+
+        await expect
+            .poll(async () => {
+                return page.evaluate(() => ({
+                    mode: document.documentElement.getAttribute(
+                        'data-theme-mode'
+                    ),
+                    theme: document.documentElement.getAttribute('data-theme'),
+                    stored: localStorage.getItem('themeMode'),
+                }));
+            })
+            .toEqual({
+                mode: 'dark',
+                theme: 'dark',
+                stored: 'dark',
+            });
+
+        await page.reload();
+
+        await expect
+            .poll(async () => {
+                return page.evaluate(() => ({
+                    mode: document.documentElement.getAttribute(
+                        'data-theme-mode'
+                    ),
+                    theme: document.documentElement.getAttribute('data-theme'),
+                }));
+            })
+            .toEqual({
+                mode: 'dark',
+                theme: 'dark',
+            });
+
+        if (await lightBtn.isVisible()) {
+            await lightBtn.click();
+            await expect
+                .poll(async () =>
+                    page.evaluate(() =>
+                        document.documentElement.getAttribute('data-theme')
+                    )
+                )
+                .toBe('light');
+        }
+    });
+
     test('footer visible con enlaces legales', async ({ page }) => {
         const footer = page.locator('footer').first();
         await expect(footer).toBeVisible();


### PR DESCRIPTION
## Bloque grande\n- Tema claro/oscuro: fix publico + soporte en admin (login y dashboard)\n- QA frontend/admin con pruebas reales de persistencia\n\n## Cambios\n- agrega fallback inmediato para .theme-btn en publico (no depende de action-router diferido)\n- agrega sistema de tema en admin (light/dark/system, persistencia en localStorage, sync de botones)\n- agrega toggles de tema en login y header del admin\n- agrega estilos dark mode para superficies clave del admin\n- agrega pruebas Playwright de tema en homepage.spec.js y dmin.spec.js\n- bump cache-bust de script.js y dmin.css/admin.js\n\n## Validacion local\n- 
pm run build\n- 
pm run test:frontend:qa:block (public: 38 passed, admin: 22 passed / 1 skipped)\n