### PR TITLE
Frontend: service-page CTA booking preselection (acne/laser)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -442,28 +442,108 @@ function initBookingCalendarLazyInit() {
     });
 }
 
+let pendingBookingServiceSelection = '';
+let pendingBookingServiceSelectionTimer = null;
+let pendingBookingServiceSelectionAttempts = 0;
+
+function clearPendingBookingServiceSelection() {
+    pendingBookingServiceSelection = '';
+    pendingBookingServiceSelectionAttempts = 0;
+    if (pendingBookingServiceSelectionTimer) {
+        window.clearTimeout(pendingBookingServiceSelectionTimer);
+        pendingBookingServiceSelectionTimer = null;
+    }
+}
+
+function scrollToBookingSection() {
+    const appointmentSection = document.getElementById('citas');
+    if (!appointmentSection) {
+        return;
+    }
+
+    const navHeight = document.querySelector('.nav')?.offsetHeight || 80;
+    const targetPosition = appointmentSection.offsetTop - navHeight - 20;
+    window.scrollTo({
+        top: targetPosition,
+        behavior: getPreferredScrollBehavior(),
+    });
+}
+
+function applyBookingServiceSelection(value) {
+    const normalized = String(value || '').trim();
+    if (!normalized) {
+        return false;
+    }
+
+    const select = document.getElementById('serviceSelect');
+    if (!select) {
+        return false;
+    }
+
+    const optionExists = Array.from(select.options || []).some(
+        function (option) {
+            return String(option.value || '').trim() === normalized;
+        }
+    );
+    if (!optionExists) {
+        return false;
+    }
+
+    if (select.value !== normalized) {
+        select.value = normalized;
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+        markBookingViewed('service_select');
+    }
+    return true;
+}
+
+function schedulePendingBookingServiceSelection() {
+    if (
+        !pendingBookingServiceSelection ||
+        pendingBookingServiceSelectionTimer !== null
+    ) {
+        return;
+    }
+
+    const runAttempt = function () {
+        pendingBookingServiceSelectionTimer = null;
+
+        if (!pendingBookingServiceSelection) {
+            return;
+        }
+
+        pendingBookingServiceSelectionAttempts += 1;
+        applyBookingServiceSelection(pendingBookingServiceSelection);
+
+        if (pendingBookingServiceSelectionAttempts >= 60) {
+            clearPendingBookingServiceSelection();
+            return;
+        }
+
+        pendingBookingServiceSelectionTimer = window.setTimeout(
+            runAttempt,
+            250
+        );
+    };
+
+    pendingBookingServiceSelectionTimer = window.setTimeout(runAttempt, 0);
+}
+
 /**
  * Selects a service in the booking form programmatically and scrolls to the appointment section.
+ * Supports deferred booking content by queueing a short retry window.
  * @param {string} value - The value of the service to select.
  */
 function fallbackSelectService(value) {
-    const select = document.getElementById('serviceSelect');
-    if (select) {
-        select.value = value;
-        select.dispatchEvent(new Event('change'));
-        markBookingViewed('service_select');
-        const appointmentSection = document.getElementById('citas');
-        if (appointmentSection) {
-            const navHeight =
-                document.querySelector('.nav')?.offsetHeight || 80;
-            const targetPosition =
-                appointmentSection.offsetTop - navHeight - 20;
-            window.scrollTo({
-                top: targetPosition,
-                behavior: getPreferredScrollBehavior(),
-            });
-        }
+    const normalized = String(value || '').trim();
+    if (normalized) {
+        pendingBookingServiceSelection = normalized;
+        pendingBookingServiceSelectionAttempts = 0;
     }
+
+    scrollToBookingSection();
+    applyBookingServiceSelection(normalized);
+    schedulePendingBookingServiceSelection();
 }
 
 let chatActionFallbackBridgeBound = false;
@@ -560,6 +640,7 @@ document.addEventListener('DOMContentLoaded', function () {
         .then(({ loadDeferredContent }) => loadDeferredContent())
         .catch(() => false)
         .then(() => {
+            schedulePendingBookingServiceSelection();
             showConsentBanner();
 
             const initHighPriorityWarmups = createOnceTask(() => {

--- a/script.js
+++ b/script.js
@@ -4,8 +4,8 @@ const e = localStorage.getItem('language'),
         : 'es';
 let n = e || t,
     o = localStorage.getItem('themeMode') || 'system',
-    a = null,
-    i = { active: !1, completed: !1, startedAt: 0, service: '', doctor: '' },
+    i = null,
+    a = { active: !1, completed: !1, startedAt: 0, service: '', doctor: '' },
     r = 0;
 const c = new Map();
 let s = [],
@@ -20,25 +20,25 @@ let s = [],
     g = null,
     h = !1,
     m = [];
-function p() {
+function f() {
     return n;
 }
-function f() {
-    return a;
+function p() {
+    return i;
 }
-function y(e) {
-    a = e;
+function w(e) {
+    i = e;
 }
-function w() {
+function y() {
     return s;
 }
 function b(e) {
     s = e;
 }
-function k() {
+function v() {
     return l;
 }
-function v(e) {
+function k(e) {
     l = e;
 }
 function P() {
@@ -93,7 +93,7 @@ function D(e) {
 }
 const B = {
         currentLang: [
-            p,
+            f,
             function (e) {
                 n = e;
             },
@@ -106,16 +106,16 @@ const B = {
                 o = e;
             },
         ],
-        currentAppointment: [f, y],
+        currentAppointment: [p, w],
         checkoutSession: [
             function () {
-                return i;
+                return a;
             },
             function (e) {
-                i = e;
+                a = e;
             },
         ],
-        reviewsCache: [w, b],
+        reviewsCache: [y, b],
         chatbotOpen: [j, L],
         conversationContext: [_, T],
     },
@@ -181,9 +181,9 @@ function V(e, t = 'info', n = '') {
         (o.id = 'toastContainer'),
         (o.className = 'toast-container'),
         document.body.appendChild(o));
-    const a = document.createElement('div');
-    a.className = `toast ${t}`;
-    const i = {
+    const i = document.createElement('div');
+    i.className = `toast ${t}`;
+    const a = {
             success: n || 'Exito',
             error: n || 'Error',
             warning: n || 'Advertencia',
@@ -194,12 +194,12 @@ function V(e, t = 'info', n = '') {
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
             .replace(/"/g, '&quot;');
-    ((a.innerHTML = `\n        <i class="fas ${{ success: 'fa-check-circle', error: 'fa-times-circle', warning: 'fa-exclamation-circle', info: 'fa-info-circle' }[t]} toast-icon"></i>\n        <div class="toast-content">\n            <div class="toast-title">${i[t]}</div>\n            <div class="toast-message">${r}</div>\n        </div>\n        <button type="button" class="toast-close" data-action="toast-close">\n            <i class="fas fa-times"></i>\n        </button>\n        <div class="toast-progress"></div>\n    `),
-        o.appendChild(a),
+    ((i.innerHTML = `\n        <i class="fas ${{ success: 'fa-check-circle', error: 'fa-times-circle', warning: 'fa-exclamation-circle', info: 'fa-info-circle' }[t]} toast-icon"></i>\n        <div class="toast-content">\n            <div class="toast-title">${a[t]}</div>\n            <div class="toast-message">${r}</div>\n        </div>\n        <button type="button" class="toast-close" data-action="toast-close">\n            <i class="fas fa-times"></i>\n        </button>\n        <div class="toast-progress"></div>\n    `),
+        o.appendChild(i),
         setTimeout(() => {
-            a.parentElement &&
-                ((a.style.animation = 'slideIn 0.3s ease reverse'),
-                setTimeout(() => a.remove(), 300));
+            i.parentElement &&
+                ((i.style.animation = 'slideIn 0.3s ease reverse'),
+                setTimeout(() => i.remove(), 300));
         }, 5e3));
 }
 function G(e, t) {
@@ -221,20 +221,20 @@ function Q(e) {
         cacheKey: t,
         src: n,
         scriptDataAttribute: o,
-        resolveModule: a,
-        isModuleReady: i = (e) => !!e,
+        resolveModule: i,
+        isModuleReady: a = (e) => !!e,
         onModuleReady: r,
         missingApiError: c = 'Deferred module loaded without expected API',
         loadError: s = 'No se pudo cargar el modulo diferido',
         logLabel: l = '',
     } = e || {};
-    if (!t || !n || !o || 'function' != typeof a)
+    if (!t || !n || !o || 'function' != typeof i)
         return Promise.reject(
             new Error('Invalid deferred module configuration')
         );
     const u = () => {
-            const e = a();
-            return i(e) ? ('function' == typeof r && r(e), e) : null;
+            const e = i();
+            return a(e) ? ('function' == typeof r && r(e), e) : null;
         },
         d = u();
     if (d) return Promise.resolve(d);
@@ -265,8 +265,8 @@ function Y(e, t = {}) {
     const {
         idleTimeout: n = 2e3,
         fallbackDelay: o = 1200,
-        skipOnConstrained: a = !0,
-        constrainedDelay: i = o,
+        skipOnConstrained: i = !0,
+        constrainedDelay: a = o,
     } = t;
     return (function () {
         const e =
@@ -279,15 +279,15 @@ function Y(e, t = {}) {
                 !/(^|[^0-9])2g/.test(String(e.effectiveType || '')))
         );
     })()
-        ? !a && (setTimeout(e, i), !0)
+        ? !i && (setTimeout(e, a), !0)
         : ('function' == typeof window.requestIdleCallback
               ? window.requestIdleCallback(e, { timeout: n })
               : setTimeout(e, o),
           !0);
 }
 function X(e, t, n, o = !0) {
-    const a = document.querySelector(e);
-    return !!a && (a.addEventListener(t, n, { once: !0, passive: o }), !0);
+    const i = document.querySelector(e);
+    return !!i && (i.addEventListener(t, n, { once: !0, passive: o }), !0);
 }
 function Z(e) {
     let t = !1;
@@ -314,17 +314,17 @@ function ee(e, t = {}) {
     };
 }
 function te(e, t, n = {}) {
-    const { threshold: o = 0.05, rootMargin: a = '0px', onNoObserver: i } = n;
+    const { threshold: o = 0.05, rootMargin: i = '0px', onNoObserver: a } = n;
     if (!e) return !1;
     if (!('IntersectionObserver' in window))
-        return ('function' == typeof i && i(), !1);
+        return ('function' == typeof a && a(), !1);
     const r = new IntersectionObserver(
         (e) => {
             e.forEach((e) => {
                 e.isIntersecting && (t(e), r.disconnect());
             });
         },
-        { threshold: o, rootMargin: a }
+        { threshold: o, rootMargin: i }
     );
     return (r.observe(e), !0);
 }
@@ -338,14 +338,14 @@ function oe(e, t, n) {
         if ('function' == typeof n) return n(e);
     });
 }
-const ae = $('/js/engines/ui-bundle.js'),
-    ie = window.matchMedia
+const ie = $('/js/engines/ui-bundle.js'),
+    ae = window.matchMedia
         ? window.matchMedia('(prefers-color-scheme: dark)')
         : null;
 function re() {
     return Q({
         cacheKey: 'theme-engine',
-        src: ae,
+        src: ie,
         scriptDataAttribute: 'data-ui-bundle',
         resolveModule: () => window.Piel && window.Piel.ThemeEngine,
         isModuleReady: (e) => !(!e || 'function' != typeof e.init),
@@ -357,7 +357,7 @@ function re() {
                 },
                 themeStorageKey: 'themeMode',
                 validThemeModes: Array.from(W),
-                getSystemThemeQuery: () => ie,
+                getSystemThemeQuery: () => ae,
             }),
         missingApiError: 'theme-engine loaded without API',
         loadError: 'No se pudo cargar theme-engine.js',
@@ -409,15 +409,15 @@ async function he(e, t = {}) {
         Object.entries(t.query).forEach(([e, t]) => {
             null != t && '' !== t && o.set(e, String(t));
         });
-    const a = `${N}?${o.toString()}`,
-        i = {
+    const i = `${N}?${o.toString()}`,
+        a = {
             method: n,
             credentials: 'same-origin',
             headers: { Accept: 'application/json' },
         };
     void 0 !== t.body &&
-        ((i.headers['Content-Type'] = 'application/json'),
-        (i.body = JSON.stringify(t.body)));
+        ((a.headers['Content-Type'] = 'application/json'),
+        (a.body = JSON.stringify(t.body)));
     const c = Number.isFinite(t.timeoutMs)
             ? Math.max(1500, Number(t.timeoutMs))
             : 9e3,
@@ -429,8 +429,8 @@ async function he(e, t = {}) {
         l = !0 !== t.silentSlowNotice,
         u = new Set([408, 425, 429, 500, 502, 503, 504]);
     function d(e, t = 0, n = !1, o = '') {
-        const a = new Error(e);
-        return ((a.status = t), (a.retryable = n), (a.code = o), a);
+        const i = new Error(e);
+        return ((i.status = t), (i.retryable = n), (i.code = o), i);
     }
     let g = null;
     for (let e = 0; e <= s; e += 1) {
@@ -450,7 +450,7 @@ async function he(e, t = {}) {
                     ));
             }, 1200));
         try {
-            const e = await fetch(a, { ...i, signal: t.signal }),
+            const e = await fetch(i, { ...a, signal: t.signal }),
                 n = await e.text();
             let o = {};
             try {
@@ -502,7 +502,7 @@ async function he(e, t = {}) {
     throw g || new Error('No se pudo completar la solicitud');
 }
 const me = $('/js/engines/booking-utils.js');
-function pe() {
+function fe() {
     return Q({
         cacheKey: 'booking-utils',
         src: me,
@@ -512,9 +512,9 @@ function pe() {
         onModuleReady: (e) =>
             e.init({
                 apiRequest: he,
-                getCurrentLang: p,
-                getPaymentConfig: k,
-                setPaymentConfig: v,
+                getCurrentLang: f,
+                getPaymentConfig: v,
+                setPaymentConfig: k,
                 getPaymentConfigLoaded: P,
                 setPaymentConfigLoaded: E,
                 getPaymentConfigLoadedAt: C,
@@ -529,20 +529,20 @@ function pe() {
         logLabel: 'Payment gateway engine',
     });
 }
-async function fe() {
-    return oe(pe, (e) => e.loadPaymentConfig());
+async function pe() {
+    return oe(fe, (e) => e.loadPaymentConfig());
 }
-async function ye() {
-    return oe(pe, (e) => e.loadStripeSdk());
+async function we() {
+    return oe(fe, (e) => e.loadStripeSdk());
 }
-async function we(e) {
-    return oe(pe, (t) => t.createPaymentIntent(e));
+async function ye(e) {
+    return oe(fe, (t) => t.createPaymentIntent(e));
 }
 async function be(e) {
-    return oe(pe, (t) => t.verifyPaymentIntent(e));
+    return oe(fe, (t) => t.verifyPaymentIntent(e));
 }
-let ke = null;
-function ve() {
+let ve = null;
+function ke() {
     const e = ((window.Piel || {}).config || {}).captcha || {};
     return {
         provider: String(e.provider || '')
@@ -556,10 +556,10 @@ async function Pe(e) {
     const t = String(e || '').trim() || 'submit';
     try {
         const e = await (function () {
-            if (ke) return ke;
-            const e = ve();
+            if (ve) return ve;
+            const e = ke();
             return e.provider && e.siteKey && e.scriptUrl
-                ? ((ke = new Promise((t) => {
+                ? ((ve = new Promise((t) => {
                       const n = document.createElement('script');
                       ((n.src = e.scriptUrl),
                           (n.async = !0),
@@ -568,11 +568,11 @@ async function Pe(e) {
                           (n.onerror = () => t(null)),
                           document.head.appendChild(n));
                   })),
-                  ke)
+                  ve)
                 : Promise.resolve(null);
         })();
         if (!e) return null;
-        const n = ve().siteKey;
+        const n = ke().siteKey;
         if ('recaptcha' === e)
             return window.grecaptcha &&
                 'function' == typeof window.grecaptcha.ready
@@ -600,29 +600,29 @@ async function Pe(e) {
                 (e.style.display = 'none'),
                 document.body.appendChild(e),
                 new Promise((o) => {
-                    let a = null;
-                    const i = () => {
+                    let i = null;
+                    const a = () => {
                         try {
-                            null !== a &&
+                            null !== i &&
                                 window.turnstile &&
                                 'function' == typeof window.turnstile.remove &&
-                                window.turnstile.remove(a);
+                                window.turnstile.remove(i);
                         } catch (e) {}
                         e.remove();
                     };
                     try {
-                        a = window.turnstile.render(e, {
+                        i = window.turnstile.render(e, {
                             sitekey: n,
                             action: t,
                             callback: (e) => {
-                                (i(), o(e || null));
+                                (a(), o(e || null));
                             },
                             'error-callback': () => {
-                                (i(), o(null));
+                                (a(), o(null));
                             },
                         });
                     } catch (e) {
-                        (i(), o(null));
+                        (a(), o(null));
                     }
                 })
             );
@@ -747,11 +747,11 @@ function We(e = {}) {
     o &&
         !Object.prototype.hasOwnProperty.call(t, 'ab_variant') &&
         (t.ab_variant = o);
-    const a = Ke(n.source, '');
+    const i = Ke(n.source, '');
     return (
-        a &&
+        i &&
             !Object.prototype.hasOwnProperty.call(t, 'source') &&
-            (t.source = a),
+            (t.source = i),
         t
     );
 }
@@ -785,7 +785,7 @@ function ze(e, t = {}) {
                   t)
                 : t;
         })(We(t)),
-        a = [
+        i = [
             n,
             o.step || '',
             o.payment_method || '',
@@ -793,9 +793,9 @@ function ze(e, t = {}) {
             o.reason || '',
             o.source || '',
         ].join('|'),
-        i = Date.now();
-    if (i - (Ue.get(a) || 0) < 1200) return;
-    Ue.set(a, i);
+        a = Date.now();
+    if (a - (Ue.get(i) || 0) < 1200) return;
+    Ue.set(i, a);
     const r = JSON.stringify({ event: n, params: o });
     try {
         if (navigator.sendBeacon) {
@@ -886,20 +886,20 @@ async function et(e) {
                 };
             const n = new Array(t.length),
                 o = Math.max(1, Math.min(2, t.length));
-            let a = 0;
+            let i = 0;
             return (
                 await Promise.all(
                     Array.from({ length: o }, () =>
                         (async () => {
-                            for (; a < t.length; ) {
-                                const e = a;
-                                a += 1;
+                            for (; i < t.length; ) {
+                                const e = i;
+                                i += 1;
                                 const o = t[e],
-                                    i = await De(o, { retries: 2 });
+                                    a = await De(o, { retries: 2 });
                                 n[e] = {
-                                    name: i.transferProofName || o.name || '',
-                                    url: i.transferProofUrl || '',
-                                    path: i.transferProofPath || '',
+                                    name: a.transferProofName || o.name || '',
+                                    url: a.transferProofUrl || '',
+                                    path: a.transferProofPath || '',
                                 };
                             }
                         })()
@@ -940,12 +940,12 @@ function tt() {
                     R.checkoutSession.active = !0 === e;
                 },
                 startCheckoutSession: ot,
-                setCheckoutStep: at,
-                completeCheckoutSession: it,
+                setCheckoutStep: it,
+                completeCheckoutSession: at,
                 maybeTrackCheckoutAbandon: rt,
-                loadPaymentConfig: fe,
-                loadStripeSdk: ye,
-                createPaymentIntent: we,
+                loadPaymentConfig: pe,
+                loadStripeSdk: we,
+                createPaymentIntent: ye,
                 verifyPaymentIntent: be,
                 buildAppointmentPayload: et,
                 stripTransientAppointmentFields: Ze,
@@ -977,10 +977,10 @@ function nt() {
 function ot(e, t = {}) {
     oe(Fe, (n) => n.startCheckoutSession(e, t));
 }
-function at(e, t = {}) {
+function it(e, t = {}) {
     oe(Fe, (n) => n.setCheckoutStep(e, t));
 }
-function it(e) {
+function at(e) {
     oe(Fe, (t) => t.completeCheckoutSession(e));
 }
 function rt(e = 'unknown') {
@@ -1019,12 +1019,12 @@ function ut() {
         validateCasePhotoFiles: dt,
         markBookingViewed: Ge,
         startCheckoutSession: ot,
-        setCheckoutStep: at,
+        setCheckoutStep: it,
         trackEvent: $e,
         normalizeAnalyticsLabel: Ve,
         openPaymentModal: ht,
         debugLog: K,
-        setCurrentAppointment: y,
+        setCurrentAppointment: w,
     };
 }
 function dt(e) {
@@ -1046,8 +1046,8 @@ function dt(e) {
                 );
             const e = String(n.type || '').toLowerCase(),
                 o = t.has(e),
-                a = /\.(jpe?g|png|webp)$/i.test(String(n.name || ''));
-            if (!o && !a)
+                i = /\.(jpe?g|png|webp)$/i.test(String(n.name || ''));
+            if (!o && !i)
                 throw new Error(
                     'es' === R.currentLang
                         ? 'Solo se permiten imágenes JPG, PNG o WEBP.'
@@ -1103,7 +1103,7 @@ function mt(e = {}) {
     const o = document.getElementById('paymentModal');
     (o && o.classList.remove('active'), (document.body.style.overflow = ''));
 }
-async function pt() {
+async function ft() {
     return oe(
         tt,
         (e) => e.processPayment(),
@@ -1112,31 +1112,31 @@ async function pt() {
         }
     );
 }
-let ft = null;
-function yt() {
-    return (ft || (ft = import('./js/chunks/ui-C4GEqQxn.js')), ft);
+let pt = null;
+function wt() {
+    return (pt || (pt = import('./js/chunks/ui-C4GEqQxn.js')), pt);
 }
-let wt = null;
+let yt = null;
 function bt() {
-    return (wt || (wt = import('./js/chunks/engagement-CxyxLpwi.js')), wt);
+    return (yt || (yt = import('./js/chunks/engagement-CxyxLpwi.js')), yt);
 }
-let kt = null,
-    vt = null;
+let vt = null,
+    kt = null;
 function Pt() {
-    return (vt || (vt = import('./js/chunks/reschedule-CiSqh0C5.js')), vt);
+    return (kt || (kt = import('./js/chunks/reschedule-CiSqh0C5.js')), kt);
 }
 function Et(e) {
-    yt()
+    wt()
         .then((t) => t.toggleMobileMenu(e))
         .catch(() => {});
 }
 function Ct() {
-    yt()
+    wt()
         .then((e) => e.startWebVideo())
         .catch(() => {});
 }
 function St() {
-    yt()
+    wt()
         .then((e) => e.closeVideoModal())
         .catch(() => {});
 }
@@ -1151,7 +1151,7 @@ function At() {
         .catch(() => {});
 }
 function jt() {
-    (kt || (kt = import('./js/chunks/success-modal-0x3ehaiL.js')), kt)
+    (vt || (vt = import('./js/chunks/success-modal-0x3ehaiL.js')), vt)
         .then((e) => e.closeSuccessModal())
         .catch(() => {});
 }
@@ -1203,7 +1203,7 @@ function Bt() {
                 closeReviewModal: At,
                 closeVideoModal: St,
                 closePaymentModal: mt,
-                processPayment: pt,
+                processPayment: ft,
                 closeSuccessModal: jt,
                 closeRescheduleModal: Lt,
                 submitReschedule: _t,
@@ -1367,12 +1367,12 @@ function on() {
         t = 'en' === R.currentLang ? 'en' : 'es',
         n = Xt[e] || Xt[Jt],
         o = n[t] || n.es,
-        a = document.querySelector('.hero-subtitle[data-i18n="hero_subtitle"]');
-    a && o.subtitle && (a.textContent = o.subtitle);
-    const i = document.querySelector(
+        i = document.querySelector('.hero-subtitle[data-i18n="hero_subtitle"]');
+    i && o.subtitle && (i.textContent = o.subtitle);
+    const a = document.querySelector(
         '.hero-actions .btn-primary[data-i18n="hero_cta_primary"]'
     );
-    (i && o.primaryCta && (i.textContent = o.primaryCta),
+    (a && o.primaryCta && (a.textContent = o.primaryCta),
         document.documentElement.setAttribute('data-hero-variant', e));
 }
 ((window.Piel.getExperimentContext = function () {
@@ -1406,7 +1406,41 @@ function on() {
 const an = $('/styles-deferred.css?v=ui-20260221-deferred18-fullcssfix1');
 let rn = null,
     cn = !1;
-let sn = !1;
+let sn = '',
+    ln = null,
+    un = 0;
+function dn(e) {
+    const t = String(e || '').trim();
+    if (!t) return !1;
+    const n = document.getElementById('serviceSelect');
+    return (
+        !!n &&
+        !!Array.from(n.options || []).some(function (e) {
+            return String(e.value || '').trim() === t;
+        }) &&
+        (n.value !== t &&
+            ((n.value = t),
+            n.dispatchEvent(new Event('change', { bubbles: !0 })),
+            Ge('service_select')),
+        !0)
+    );
+}
+function gn() {
+    if (!sn || null !== ln) return;
+    const e = function () {
+        if (((ln = null), sn)) {
+            if (((un += 1), dn(sn), un >= 60))
+                return (
+                    (sn = ''),
+                    (un = 0),
+                    void (ln && (window.clearTimeout(ln), (ln = null)))
+                );
+            ln = window.setTimeout(e, 250);
+        }
+    };
+    ln = window.setTimeout(e, 0);
+}
+let hn = !1;
 (document.addEventListener('DOMContentLoaded', function () {
     (document.querySelectorAll('a[href^="URL_"]').forEach((e) => {
         (e.removeAttribute('href'),
@@ -1414,15 +1448,15 @@ let sn = !1;
             e.classList.add('is-disabled-link'));
     }),
         Nt(),
-        sn ||
-            ((sn = !0),
+        hn ||
+            ((hn = !0),
             document.addEventListener('click', async function (e) {
                 const t = e.target instanceof Element ? e.target : null;
                 if (!t) return;
                 const n = t.closest('[data-action]');
                 if (!n) return;
                 const o = String(n.getAttribute('data-action') || '').trim(),
-                    a = n.getAttribute('data-value') || '';
+                    i = n.getAttribute('data-value') || '';
                 switch (o) {
                     case 'toggle-chatbot':
                         (e.preventDefault(),
@@ -1442,12 +1476,12 @@ let sn = !1;
                     case 'quick-message':
                         (e.preventDefault(),
                             e.stopImmediatePropagation(),
-                            (await Ut()).sendQuickMessage(a));
+                            (await Ut()).sendQuickMessage(i));
                         break;
                     case 'chat-booking':
                         (e.preventDefault(),
                             e.stopImmediatePropagation(),
-                            (await Ut()).handleChatBookingSelection(a));
+                            (await Ut()).handleChatBookingSelection(i));
                         break;
                     case 'start-booking':
                         (e.preventDefault(),
@@ -1458,25 +1492,24 @@ let sn = !1;
                         (e.preventDefault(),
                             e.stopImmediatePropagation(),
                             (function (e) {
-                                const t =
-                                    document.getElementById('serviceSelect');
-                                if (t) {
-                                    ((t.value = e),
-                                        t.dispatchEvent(new Event('change')),
-                                        Ge('service_select'));
-                                    const n = document.getElementById('citas');
-                                    if (n) {
+                                const t = String(e || '').trim();
+                                (t && ((sn = t), (un = 0)),
+                                    (function () {
                                         const e =
+                                            document.getElementById('citas');
+                                        if (!e) return;
+                                        const t =
                                                 document.querySelector('.nav')
                                                     ?.offsetHeight || 80,
-                                            t = n.offsetTop - e - 20;
+                                            n = e.offsetTop - t - 20;
                                         window.scrollTo({
-                                            top: t,
+                                            top: n,
                                             behavior: tn(),
                                         });
-                                    }
-                                }
-                            })(a));
+                                    })(),
+                                    dn(t),
+                                    gn());
+                            })(i));
                 }
             }),
             document.addEventListener('change', async function (e) {
@@ -1580,7 +1613,7 @@ let sn = !1;
         Gt.then(({ loadDeferredContent: e }) => e())
             .catch(() => !1)
             .then(() => {
-                oe(Nt, (e) => e.initCookieBanner());
+                (gn(), oe(Nt, (e) => e.initCookieBanner()));
                 const e = Z(() => {
                         (!(function () {
                             const e = () => {
@@ -1715,14 +1748,14 @@ let sn = !1;
         if (!n) return;
         const o = n.closest('a[href^="#"]');
         if (!o) return;
-        const a = o.getAttribute('href');
-        if (!a || '#' === a) return;
-        const i = document.querySelector(a);
-        if (!i) return;
+        const i = o.getAttribute('href');
+        if (!i || '#' === i) return;
+        const a = document.querySelector(i);
+        if (!a) return;
         t.preventDefault();
         const r = e ? e.offsetHeight : 0,
-            c = i.offsetTop - r - 20;
-        ('#citas' === a && Ge(`cta_click_${nn()}`),
+            c = a.offsetTop - r - 20;
+        ('#citas' === i && Ge(`cta_click_${nn()}`),
             window.scrollTo({ top: c, behavior: tn() }));
     }),
         document.addEventListener('click', function (e) {
@@ -1764,8 +1797,8 @@ let sn = !1;
                     if (e.isIntersecting) {
                         const n = e.target,
                             o = n.dataset.src,
-                            a = n.dataset.srcset;
-                        (a && (n.srcset = a),
+                            i = n.dataset.srcset;
+                        (i && (n.srcset = i),
                             (n.src = o),
                             n.classList.add('loaded'),
                             t.unobserve(n));
@@ -1793,7 +1826,7 @@ let sn = !1;
             } catch (e) {}
     }));
 export {
-    at as A,
+    it as A,
     ot as B,
     x as C,
     U as D,
@@ -1801,7 +1834,7 @@ export {
     je as F,
     te as G,
     b as H,
-    w as I,
+    y as I,
     Ie as J,
     Te as K,
     z as L,
@@ -1819,20 +1852,20 @@ export {
     O as h,
     D as i,
     I as j,
-    f as k,
+    p as k,
     Q as l,
     T as m,
     _ as n,
     K as o,
     R as p,
-    y as q,
+    w as q,
     oe as r,
     V as s,
     $e as t,
-    p as u,
+    f as u,
     ht as v,
     ne as w,
     Pe as x,
     _e as y,
-    it as z,
+    at as z,
 };

--- a/servicios/acne.html
+++ b/servicios/acne.html
@@ -266,8 +266,15 @@
                     </li>
                 </ul>
                 <div class="nav-actions">
-                    <a href="#citas" class="nav-cta" data-i18n="nav_book"
-                        >Reservar Cita</a
+                    <a
+                        href="#citas"
+                        class="nav-cta"
+                        data-i18n="nav_book"
+                        data-action="select-service"
+                        data-value="acne"
+                        data-qa="service-nav-booking-cta"
+                    >
+                        Reservar Cita</a
                     >
                 </div>
                 <button
@@ -364,6 +371,9 @@
                         href="#citas"
                         class="btn btn-primary"
                         data-i18n="hero_cta_primary"
+                        data-action="select-service"
+                        data-value="acne"
+                        data-qa="service-hero-booking-cta"
                         >Reservar Consulta</a
                     >
                     <a
@@ -442,7 +452,13 @@
                         </article>
                     </div>
                     <div class="service-intent-actions">
-                        <a href="#citas" class="btn btn-primary">
+                        <a
+                            href="#citas"
+                            class="btn btn-primary"
+                            data-action="select-service"
+                            data-value="acne"
+                            data-qa="service-intent-booking-cta"
+                        >
                             Reservar evaluacion de acne
                         </a>
                         <a
@@ -1698,21 +1714,24 @@
                                 <option
                                     value="consulta"
                                     data-price="40"
+                                    data-service-tax="0"
                                     data-i18n="opt_consulta"
                                     selected
                                 >
-                                    Consulta Dermatol�gica - $40
+                                    Consulta Dermatologica - $40
                                 </option>
                                 <option
                                     value="telefono"
                                     data-price="25"
+                                    data-service-tax="0"
                                     data-i18n="opt_telefono"
                                 >
-                                    Consulta Telef�nica - $25
+                                    Consulta Telefonica - $25
                                 </option>
                                 <option
                                     value="video"
                                     data-price="30"
+                                    data-service-tax="0"
                                     data-i18n="opt_video"
                                 >
                                     Video Consulta - $30
@@ -1720,16 +1739,34 @@
                                 <option
                                     value="laser"
                                     data-price="150"
+                                    data-service-tax="0.15"
                                     data-i18n="opt_laser"
                                 >
-                                    Tratamiento L�ser - desde $150
+                                    Tratamiento Laser - desde $150
                                 </option>
                                 <option
                                     value="rejuvenecimiento"
                                     data-price="120"
+                                    data-service-tax="0.15"
                                     data-i18n="opt_rejuvenation"
                                 >
                                     Rejuvenecimiento - desde $120
+                                </option>
+                                <option
+                                    value="acne"
+                                    data-price="80"
+                                    data-service-tax="0"
+                                    data-i18n="opt_acne"
+                                >
+                                    Tratamiento de Acne - desde $80
+                                </option>
+                                <option
+                                    value="cancer"
+                                    data-price="70"
+                                    data-service-tax="0"
+                                    data-i18n="opt_cancer"
+                                >
+                                    Deteccion de Cancer - desde $70
                                 </option>
                             </select>
                         </div>
@@ -2009,7 +2046,14 @@
                     <a href="#consultorio" data-i18n="nav_clinic"
                         >Consultorio</a
                     >
-                    <a href="#citas" data-i18n="nav_book">Reservar</a>
+                    <a
+                        href="#citas"
+                        data-i18n="nav_book"
+                        data-action="select-service"
+                        data-value="acne"
+                    >
+                        Reservar
+                    </a>
                 </div>
 
                 <div class="footer-legal">
@@ -2500,7 +2544,13 @@
         </div>
 
         <div class="quick-dock" aria-label="Acciones rapidas">
-            <a href="#citas" class="quick-dock-item">
+            <a
+                href="#citas"
+                class="quick-dock-item"
+                data-action="select-service"
+                data-value="acne"
+                data-qa="service-quickdock-booking-cta"
+            >
                 <i class="fas fa-calendar-check"></i>
                 <span>Reservar</span>
             </a>

--- a/servicios/laser.html
+++ b/servicios/laser.html
@@ -269,8 +269,15 @@
                     </li>
                 </ul>
                 <div class="nav-actions">
-                    <a href="#citas" class="nav-cta" data-i18n="nav_book"
-                        >Reservar Cita</a
+                    <a
+                        href="#citas"
+                        class="nav-cta"
+                        data-i18n="nav_book"
+                        data-action="select-service"
+                        data-value="laser"
+                        data-qa="service-nav-booking-cta"
+                    >
+                        Reservar Cita</a
                     >
                 </div>
                 <button
@@ -367,6 +374,9 @@
                         href="#citas"
                         class="btn btn-primary"
                         data-i18n="hero_cta_primary"
+                        data-action="select-service"
+                        data-value="laser"
+                        data-qa="service-hero-booking-cta"
                         >Reservar Consulta</a
                     >
                     <a
@@ -448,7 +458,13 @@
                         </article>
                     </div>
                     <div class="service-intent-actions">
-                        <a href="#citas" class="btn btn-primary">
+                        <a
+                            href="#citas"
+                            class="btn btn-primary"
+                            data-action="select-service"
+                            data-value="laser"
+                            data-qa="service-intent-booking-cta"
+                        >
                             Reservar valoracion laser
                         </a>
                         <a
@@ -1704,21 +1720,24 @@
                                 <option
                                     value="consulta"
                                     data-price="40"
+                                    data-service-tax="0"
                                     data-i18n="opt_consulta"
                                     selected
                                 >
-                                    Consulta Dermatol�gica - $40
+                                    Consulta Dermatologica - $40
                                 </option>
                                 <option
                                     value="telefono"
                                     data-price="25"
+                                    data-service-tax="0"
                                     data-i18n="opt_telefono"
                                 >
-                                    Consulta Telef�nica - $25
+                                    Consulta Telefonica - $25
                                 </option>
                                 <option
                                     value="video"
                                     data-price="30"
+                                    data-service-tax="0"
                                     data-i18n="opt_video"
                                 >
                                     Video Consulta - $30
@@ -1726,16 +1745,34 @@
                                 <option
                                     value="laser"
                                     data-price="150"
+                                    data-service-tax="0.15"
                                     data-i18n="opt_laser"
                                 >
-                                    Tratamiento L�ser - desde $150
+                                    Tratamiento Laser - desde $150
                                 </option>
                                 <option
                                     value="rejuvenecimiento"
                                     data-price="120"
+                                    data-service-tax="0.15"
                                     data-i18n="opt_rejuvenation"
                                 >
                                     Rejuvenecimiento - desde $120
+                                </option>
+                                <option
+                                    value="acne"
+                                    data-price="80"
+                                    data-service-tax="0"
+                                    data-i18n="opt_acne"
+                                >
+                                    Tratamiento de Acne - desde $80
+                                </option>
+                                <option
+                                    value="cancer"
+                                    data-price="70"
+                                    data-service-tax="0"
+                                    data-i18n="opt_cancer"
+                                >
+                                    Deteccion de Cancer - desde $70
                                 </option>
                             </select>
                         </div>
@@ -2015,7 +2052,14 @@
                     <a href="#consultorio" data-i18n="nav_clinic"
                         >Consultorio</a
                     >
-                    <a href="#citas" data-i18n="nav_book">Reservar</a>
+                    <a
+                        href="#citas"
+                        data-i18n="nav_book"
+                        data-action="select-service"
+                        data-value="laser"
+                    >
+                        Reservar
+                    </a>
                 </div>
 
                 <div class="footer-legal">
@@ -2506,7 +2550,13 @@
         </div>
 
         <div class="quick-dock" aria-label="Acciones rapidas">
-            <a href="#citas" class="quick-dock-item">
+            <a
+                href="#citas"
+                class="quick-dock-item"
+                data-action="select-service"
+                data-value="laser"
+                data-qa="service-quickdock-booking-cta"
+            >
                 <i class="fas fa-calendar-check"></i>
                 <span>Reservar</span>
             </a>

--- a/tests/service-pages-qa.spec.js
+++ b/tests/service-pages-qa.spec.js
@@ -7,12 +7,14 @@ const SERVICE_PAGES = [
         name: 'acne',
         intentBadge: /acne/i,
         ctaHref: '#citas',
+        bookingValue: 'acne',
     },
     {
         path: '/servicios/laser.html',
         name: 'laser',
         intentBadge: /laser/i,
         ctaHref: '#citas',
+        bookingValue: 'laser',
     },
 ];
 
@@ -215,6 +217,58 @@ test.describe('Service pages conversion QA', () => {
             expect(after.top).toBeLessThan(beforeTop);
 
             await expect(quickDockReserve).toBeVisible();
+        }
+    });
+
+    test('service booking CTAs preselect matching service even when citas is deferred', async ({
+        page,
+    }) => {
+        for (const service of SERVICE_PAGES) {
+            await page.setViewportSize({ width: 390, height: 844 });
+            await waitForStablePage(page, service.path);
+
+            const heroBookingCta = page
+                .locator('[data-qa="service-hero-booking-cta"]')
+                .first();
+            await expect(heroBookingCta).toBeVisible();
+            await heroBookingCta.click({ force: true });
+
+            await expect
+                .poll(
+                    async () =>
+                        page.evaluate(() => {
+                            const select =
+                                document.getElementById('serviceSelect');
+                            return select ? select.value : null;
+                        }),
+                    { timeout: 12000 }
+                )
+                .toBe(service.bookingValue);
+
+            await page.evaluate(() => {
+                const select = document.getElementById('serviceSelect');
+                if (!select) return;
+                select.value = 'consulta';
+                select.dispatchEvent(new Event('change', { bubbles: true }));
+            });
+
+            const quickDockBookingCta = page
+                .locator('[data-qa="service-quickdock-booking-cta"]')
+                .first();
+            await expect(quickDockBookingCta).toBeVisible();
+            await quickDockBookingCta.click({ force: true });
+
+            await expect
+                .poll(
+                    async () =>
+                        page.evaluate(() => {
+                            const select =
+                                document.getElementById('serviceSelect');
+                            return select ? select.value : null;
+                        }),
+                    { timeout: 6000 }
+                )
+                .toBe(service.bookingValue);
         }
     });
 });


### PR DESCRIPTION
## Summary
- wires service-page conversion CTAs to `data-action="select-service"` with explicit values (`acne`/`laser`)
- adds deferred-safe pending selection logic in `js/main.js` so preselection survives lazy/deferred booking initialization
- aligns service-page booking select options with booking catalog by adding `acne` (+ `cancer`) and `data-service-tax` metadata
- extends Playwright service QA to assert CTA-driven preselection on hero and quick-dock

## Validation
- `npm run build`
- `npx playwright test tests/service-pages-qa.spec.js`
