### PR TITLE
Frontend: telemedicina booking CTA preselection + mobile menu handoff

### DIFF
--- a/js/engines/data-bundle.js
+++ b/js/engines/data-bundle.js
@@ -1,1 +1,727 @@
-!function(){"use strict";!function(){let e=null;const t="/api.php",o="file:"===window.location.protocol;let n=0;const a=new Map,r=new Map,s=new Map,i=new Map;function c(){return e&&"function"==typeof e.getCurrentLang&&e.getCurrentLang()||"es"}function l(t,o){return e&&"function"==typeof e.storageGetJSON?e.storageGetJSON(t,o):o}function u(t,o){e&&"function"==typeof e.storageSetJSON&&e.storageSetJSON(t,o)}function d(t){return e&&"function"==typeof e.waitMs?e.waitMs(t):new Promise(e=>setTimeout(e,t))}function f(e){return 450*2**Math.max(0,Math.min(5,Number(e)||0))+Math.floor(180*Math.random())}function w(e){if(!e||"object"!=typeof e)return!1;const t=String(e.name||"").toLowerCase(),o=String(e.message||"").toLowerCase();return"typeerror"===t||o.includes("failed to fetch")||o.includes("networkerror")||o.includes("network request failed")||o.includes("load failed")||o.includes("fetch")}function p(e,t=0,o=!1,n=""){const a=new Error(e);return a.status=t,a.retryable=o,a.code=n,a}async function m(o,r={}){const s=String(r.method||"GET").toUpperCase(),i=new URLSearchParams({resource:o});r.query&&"object"==typeof r.query&&Object.entries(r.query).forEach(([e,t])=>{null!=t&&""!==t&&i.set(e,String(t))});const l=t+"?"+i.toString(),u={method:s,credentials:"same-origin",headers:{Accept:"application/json"}};if(new Set(["payment-intent","appointments","callbacks","reviews"]).has(o)&&e&&"function"==typeof e.getCaptchaToken)try{const t=await e.getCaptchaToken(o);t&&(u.headers["X-Captcha-Token"]=t)}catch(e){}void 0!==r.body&&(u.headers["Content-Type"]="application/json",u.body=JSON.stringify(r.body));const m=Number.isFinite(r.timeoutMs)?Math.max(1500,Number(r.timeoutMs)):9e3,g=Number.isInteger(r.retries)?Math.max(0,Number(r.retries)):"GET"===s?1:0,h=!0!==r.silentSlowNotice&&!0!==r.background,b=new Set([408,425,429,500,502,503,504]),y=async()=>{let t=null;for(let o=0;o<=g;o+=1){const a=new AbortController,r=setTimeout(()=>a.abort(),m);let s=null;h&&(s=setTimeout(()=>{const t=Date.now();var o;t-n>25e3&&(n=t,o="es"===c()?"Conectando con el servidor...":"Connecting to server...",e&&"function"==typeof e.showToast&&e.showToast(o,"info"))},1200));try{const e=await fetch(l,{...u,signal:a.signal}),t=await e.text();let o={};try{o=t?JSON.parse(t):{}}catch(t){throw p("Respuesta del servidor no es JSON valido",e.status,b.has(e.status),"invalid_json")}if(!e.ok||!1===o.ok){const t=o.error||"HTTP "+e.status,n=o.code||o.errorCode||"http_error";throw p(t,e.status,b.has(e.status),n)}return o}catch(e){const n=(()=>e&&"AbortError"===e.name?p("es"===c()?"Tiempo de espera agotado con el servidor":"Server request timed out",0,!0,"timeout"):w(e)?p("es"===c()?"No se pudo conectar con el servidor":"Could not connect to server",0,!0,"network_error"):e instanceof Error?("boolean"!=typeof e.retryable&&(e.retryable=!1),"number"!=typeof e.status&&(e.status=0),"string"==typeof e.code&&e.code||(e.code="api_error"),e):p("Error de conexion con el servidor",0,!0,"network_error"))();if(t=n,!(o<g&&!0===n.retryable))throw n;await d(f(o))}finally{clearTimeout(r),null!==s&&clearTimeout(s)}}throw t||new Error("No se pudo completar la solicitud")};if("GET"!==s||!1===r.dedupe)return y();if(a.has(l))return a.get(l);const S=y().finally(()=>{a.delete(l)});return a.set(l,S),S}function g(e="",t="",o=""){const n=String(e||"").trim(),a=String(t||"").trim(),r=String(o||"").trim();if(n)for(const e of i.keys()){if(!e.startsWith(`${n}::`))continue;if(""===a&&""===r){i.delete(e);continue}const t=e.split("::"),o=t[1]||"",s=t[2]||"";(""===a||o===a)&&(""===r||s===r)&&i.delete(e)}else i.clear()}window.Piel=window.Piel||{},window.Piel.DataEngine={init:function(t){return e=t||e||{},window.Piel&&window.Piel.DataEngine},apiRequest:m,uploadTransferProof:async function(o,n={}){const a=new FormData;a.append("proof",o);const r=new URLSearchParams({resource:"transfer-proof"}),s=`${t}?${r.toString()}`,i=Number.isFinite(n.timeoutMs)?Math.max(3e3,Number(n.timeoutMs)):16e3,l=Number.isInteger(n.retries)?Math.max(0,Number(n.retries)):1,u=new Set([408,425,429,500,502,503,504]);let p="";if(e&&"function"==typeof e.getCaptchaToken)try{p=await e.getCaptchaToken("transfer_proof")}catch(e){}let m=null;for(let e=0;e<=l;e+=1){const t=new AbortController,o=setTimeout(()=>t.abort(),i);try{const e={};p&&(e["X-Captcha-Token"]=p);const o=await fetch(s,{method:"POST",credentials:"same-origin",headers:e,body:a,signal:t.signal}),n=await o.text();let r={};try{r=n?JSON.parse(n):{}}catch(e){const t=new Error("No se pudo interpretar la respuesta de subida");throw t.retryable=u.has(o.status),t.status=o.status,t}if(!o.ok||!1===r.ok){const e=new Error(r.error||`HTTP ${o.status}`);throw e.retryable=u.has(o.status),e.status=o.status,e}return r.data||{}}catch(t){const o=(()=>{if(t&&"AbortError"===t.name){const e=new Error("es"===c()?"Tiempo de espera agotado al subir el comprobante":"Upload timed out while sending proof file");return e.retryable=!0,e.code="timeout",e}if(w(t)){const e=new Error("es"===c()?"No se pudo conectar con el servidor al subir el comprobante":"Could not connect to server while uploading proof");return e.retryable=!0,e.code="network_error",e}if(t instanceof Error)return"boolean"!=typeof t.retryable&&(t.retryable=!1),t;const e=new Error("es"===c()?"No se pudo subir el comprobante":"Unable to upload proof");return e.retryable=!0,e.code="upload_error",e})();if(m=o,!(e<l&&!0===o.retryable))throw o;await d(f(e))}finally{clearTimeout(o)}}throw m||new Error("No se pudo subir el comprobante")},invalidateBookedSlotsCache:g,loadAvailabilityData:async function(e={}){const t=e&&!0===e.forceRefresh,o=e&&!0===e.background,n=e&&!0===e.strict,a=String(e.doctor||"indiferente"),i=String(e.service||"consulta"),c=String(e.dateFrom||""),d=Number.isFinite(Number(e.days))?Number(e.days):21,f=function(e={}){return`${String(e.doctor||"indiferente")}::${String(e.service||"consulta")}::${String(e.dateFrom||"")}::${Number(e.days||21)}`}({doctor:a,service:i,dateFrom:c,days:d}),w=Date.now(),p=r.get(f);if(!t&&p&&w-p.at<6e4)return p.data;if(!t&&s.has(f))return s.get(f);const g=`availability:${f}`,h=(async()=>{try{const e={doctor:a,service:i};c&&(e.dateFrom=c),Number.isFinite(d)&&d>0&&(e.days=d);const t=await m("availability",{query:e,background:o,silentSlowNotice:o}),n=t&&t.data&&"object"==typeof t.data?t.data:{};return r.set(f,{data:n,at:Date.now(),meta:t&&t.meta&&"object"==typeof t.meta?t.meta:{}}),u(g,n),n}catch(e){if(e&&("calendar_unreachable"===e.code||String(e.message||"").toLowerCase().includes("calendar_unreachable")))throw e;const t=l(g,{});if(t&&"object"==typeof t&&Object.keys(t).length>0)return r.set(f,{data:t,at:Date.now(),meta:{source:"local_cache"}}),t;if(n)throw e;return{}}finally{s.delete(f)}})();return s.set(f,h),h},getBookedSlots:async function(e,t="",n="consulta"){const a=function(e,t="",o=""){return`${String(e||"")}::${String(t||"")}::${String(o||"")}`}(e,t,n),r=Date.now(),s=i.get(a);if(s&&r-s.at<1e4)return s.slots;try{const o={date:e};t&&(o.doctor=t),n&&(o.service=n);const s=await m("booked-slots",{query:o}),c=Array.isArray(s.data)?s.data:[];return i.set(a,{slots:c,at:r}),c}catch(n){if(n&&("calendar_unreachable"===n.code||String(n.message||"").toLowerCase().includes("calendar_unreachable")))throw n;if(!o)throw n;const s=l("appointments",[]).filter(o=>{if(o.date!==e||"cancelled"===o.status)return!1;if(t&&"indiferente"!==t){const e=o.doctor||"";if(e&&"indiferente"!==e&&e!==t)return!1}return!0}).map(e=>e.time),c=Array.from(new Set(s));return i.set(a,{slots:c,at:r}),c}},createAppointmentRecord:async function(e,t={}){const n=!1!==t.allowLocalFallback;try{const t=await m("appointments",{method:"POST",body:e}),o=l("appointments",[]);return o.push(t.data),u("appointments",o),t&&t.data?g(t.data.date||e?.date||"",t.data.doctor||e?.doctor||"",t.data.service||e?.service||""):g(e?.date||"",e?.doctor||"",e?.service||""),{appointment:t.data,emailSent:!0===t.emailSent}}catch(t){if(!o||!n)throw t;const a=l("appointments",[]),r={...e,id:Date.now(),status:"confirmed",dateBooked:(new Date).toISOString(),paymentStatus:e.paymentStatus||"pending"};return a.push(r),u("appointments",a),g(r.date||e?.date||"",r.doctor||e?.doctor||"",r.service||e?.service||""),{appointment:r,emailSent:!1}}},createCallbackRecord:async function(e){try{await m("callbacks",{method:"POST",body:e})}catch(t){if(!o)throw t;const n=l("callbacks",[]);n.push(e),u("callbacks",n)}},createReviewRecord:async function(e){try{return(await m("reviews",{method:"POST",body:e})).data}catch(t){if(!o)throw t;const n=l("reviews",[]);return n.unshift(e),u("reviews",n),e}}}}();let e=null;const t=new Set(["clinic_hours"]),o={es:null,en:null};let n=null;function a(){e&&"function"==typeof e.debugLog&&e.debugLog.apply(null,arguments)}function r(){return o.en&&"object"==typeof o.en?Promise.resolve(o.en):n||(n=fetch("/api.php?resource=content&lang=en").then(e=>{if(!e.ok)throw new Error("Failed to load EN content");return e.json()}).then(e=>(o.en=e,o.en)).catch(e=>{throw n=null,a("English translations load failed:",e),e}),n)}window.PielI18nEngine={init:function(t){return e=t||{},window.PIEL_CONTENT&&"object"==typeof window.PIEL_CONTENT&&(o.es=window.PIEL_CONTENT),window.PielI18nEngine},ensureEnglishTranslations:r,changeLanguage:async function(n){const s="en"===n?"en":"es";if(function(t){e&&"function"==typeof e.setCurrentLang&&e.setCurrentLang(t)}(s),localStorage.setItem("language",s),document.documentElement.lang=s,!o.es||"object"!=typeof o.es)try{const e=await fetch("/api.php?resource=content&lang=es");e.ok&&(o.es=await e.json())}catch(e){a("Failed to load ES content fallback",e)}if("en"===s&&!o.en)try{await r()}catch(t){e&&"function"==typeof e.showToast&&e.showToast("No se pudo cargar el paquete de idioma EN. Se mantiene Espanol.","warning")}const i=o[s]||o.es||{};document.querySelectorAll(".lang-btn").forEach(e=>{e.classList.toggle("active",e.dataset.lang===s)}),document.querySelectorAll("[data-i18n]").forEach(e=>{const o=String(e.dataset.i18n||"").trim();Object.prototype.hasOwnProperty.call(i,o)&&("INPUT"!==e.tagName&&"TEXTAREA"!==e.tagName?t.has(o)?e.innerHTML=i[o]:e.textContent=i[o]:e.placeholder=i[o])});const c=e&&"function"==typeof e.getReviewsCache?e.getReviewsCache():[];var l;return Array.isArray(c)&&c.length>0&&(l=c,e&&"function"==typeof e.renderPublicReviews&&e.renderPublicReviews(l)),document.dispatchEvent(new CustomEvent("piel:language-changed",{detail:{lang:s}})),s}};let s=null,i=!1;function c(e){if(!s||"function"!=typeof s[e])return;const t=Array.prototype.slice.call(arguments,1);return s[e].apply(null,t)}function l(e){const t=e.target instanceof Element?e.target:null;if(!t)return;const o=t.closest("[data-action]");if(!o)return;const n=String(o.getAttribute("data-action")||"").trim(),a=o.getAttribute("data-value")||"";if(n)switch(n){case"toast-close":o.closest(".toast")?.remove();break;case"set-theme":c("setThemeMode",a||"system");break;case"set-language":c("changeLanguage",a||"es");break;case"toggle-mobile-menu":c("toggleMobileMenu");break;case"start-web-video":c("startWebVideo");break;case"open-review-modal":c("openReviewModal");break;case"close-review-modal":c("closeReviewModal");break;case"close-video-modal":c("closeVideoModal");break;case"close-payment-modal":c("closePaymentModal");break;case"process-payment":c("processPayment");break;case"close-success-modal":c("closeSuccessModal");break;case"close-reschedule-modal":c("closeRescheduleModal");break;case"submit-reschedule":c("submitReschedule");break;case"toggle-chatbot":c("toggleChatbot");break;case"send-chat-message":c("sendChatMessage");break;case"chat-booking":c("handleChatBookingSelection",a);break;case"quick-message":c("sendQuickMessage",a);break;case"minimize-chat":c("minimizeChatbot");break;case"start-booking":c("startChatBooking");break;case"select-service":c("selectService",a)}}function u(e){const t=e.target instanceof Element?e.target:null;t&&t.closest('[data-action="chat-date-select"]')&&c("handleChatDateSelect",t.value)}window.Piel=window.Piel||{},window.Piel.ActionRouterEngine={init:function(e){return s=e||{},i||(i=!0,document.addEventListener("click",l),document.addEventListener("change",u)),window.Piel&&window.Piel.ActionRouterEngine?window.Piel.ActionRouterEngine:window.PielActionRouterEngine}},window.PielActionRouterEngine=window.Piel.ActionRouterEngine}();
+!(function () {
+    'use strict';
+    !(function () {
+        let e = null;
+        const t = '/api.php',
+            o = 'file:' === window.location.protocol;
+        let n = 0;
+        const a = new Map(),
+            r = new Map(),
+            i = new Map(),
+            s = new Map();
+        function c() {
+            return (
+                (e &&
+                    'function' == typeof e.getCurrentLang &&
+                    e.getCurrentLang()) ||
+                'es'
+            );
+        }
+        function l(t, o) {
+            return e && 'function' == typeof e.storageGetJSON
+                ? e.storageGetJSON(t, o)
+                : o;
+        }
+        function u(t, o) {
+            e &&
+                'function' == typeof e.storageSetJSON &&
+                e.storageSetJSON(t, o);
+        }
+        function d(t) {
+            return e && 'function' == typeof e.waitMs
+                ? e.waitMs(t)
+                : new Promise((e) => setTimeout(e, t));
+        }
+        function f(e) {
+            return (
+                450 * 2 ** Math.max(0, Math.min(5, Number(e) || 0)) +
+                Math.floor(180 * Math.random())
+            );
+        }
+        function w(e) {
+            if (!e || 'object' != typeof e) return !1;
+            const t = String(e.name || '').toLowerCase(),
+                o = String(e.message || '').toLowerCase();
+            return (
+                'typeerror' === t ||
+                o.includes('failed to fetch') ||
+                o.includes('networkerror') ||
+                o.includes('network request failed') ||
+                o.includes('load failed') ||
+                o.includes('fetch')
+            );
+        }
+        function p(e, t = 0, o = !1, n = '') {
+            const a = new Error(e);
+            return ((a.status = t), (a.retryable = o), (a.code = n), a);
+        }
+        async function m(o, r = {}) {
+            const i = String(r.method || 'GET').toUpperCase(),
+                s = new URLSearchParams({ resource: o });
+            r.query &&
+                'object' == typeof r.query &&
+                Object.entries(r.query).forEach(([e, t]) => {
+                    null != t && '' !== t && s.set(e, String(t));
+                });
+            const l = t + '?' + s.toString(),
+                u = {
+                    method: i,
+                    credentials: 'same-origin',
+                    headers: { Accept: 'application/json' },
+                };
+            if (
+                new Set([
+                    'payment-intent',
+                    'appointments',
+                    'callbacks',
+                    'reviews',
+                ]).has(o) &&
+                e &&
+                'function' == typeof e.getCaptchaToken
+            )
+                try {
+                    const t = await e.getCaptchaToken(o);
+                    t && (u.headers['X-Captcha-Token'] = t);
+                } catch (e) {}
+            void 0 !== r.body &&
+                ((u.headers['Content-Type'] = 'application/json'),
+                (u.body = JSON.stringify(r.body)));
+            const m = Number.isFinite(r.timeoutMs)
+                    ? Math.max(1500, Number(r.timeoutMs))
+                    : 9e3,
+                g = Number.isInteger(r.retries)
+                    ? Math.max(0, Number(r.retries))
+                    : 'GET' === i
+                      ? 1
+                      : 0,
+                h = !0 !== r.silentSlowNotice && !0 !== r.background,
+                b = new Set([408, 425, 429, 500, 502, 503, 504]),
+                y = async () => {
+                    let t = null;
+                    for (let o = 0; o <= g; o += 1) {
+                        const a = new AbortController(),
+                            r = setTimeout(() => a.abort(), m);
+                        let i = null;
+                        h &&
+                            (i = setTimeout(() => {
+                                const t = Date.now();
+                                var o;
+                                t - n > 25e3 &&
+                                    ((n = t),
+                                    (o =
+                                        'es' === c()
+                                            ? 'Conectando con el servidor...'
+                                            : 'Connecting to server...'),
+                                    e &&
+                                        'function' == typeof e.showToast &&
+                                        e.showToast(o, 'info'));
+                            }, 1200));
+                        try {
+                            const e = await fetch(l, {
+                                    ...u,
+                                    signal: a.signal,
+                                }),
+                                t = await e.text();
+                            let o = {};
+                            try {
+                                o = t ? JSON.parse(t) : {};
+                            } catch (t) {
+                                throw p(
+                                    'Respuesta del servidor no es JSON valido',
+                                    e.status,
+                                    b.has(e.status),
+                                    'invalid_json'
+                                );
+                            }
+                            if (!e.ok || !1 === o.ok) {
+                                const t = o.error || 'HTTP ' + e.status,
+                                    n = o.code || o.errorCode || 'http_error';
+                                throw p(t, e.status, b.has(e.status), n);
+                            }
+                            return o;
+                        } catch (e) {
+                            const n = (() =>
+                                e && 'AbortError' === e.name
+                                    ? p(
+                                          'es' === c()
+                                              ? 'Tiempo de espera agotado con el servidor'
+                                              : 'Server request timed out',
+                                          0,
+                                          !0,
+                                          'timeout'
+                                      )
+                                    : w(e)
+                                      ? p(
+                                            'es' === c()
+                                                ? 'No se pudo conectar con el servidor'
+                                                : 'Could not connect to server',
+                                            0,
+                                            !0,
+                                            'network_error'
+                                        )
+                                      : e instanceof Error
+                                        ? ('boolean' != typeof e.retryable &&
+                                              (e.retryable = !1),
+                                          'number' != typeof e.status &&
+                                              (e.status = 0),
+                                          ('string' == typeof e.code &&
+                                              e.code) ||
+                                              (e.code = 'api_error'),
+                                          e)
+                                        : p(
+                                              'Error de conexion con el servidor',
+                                              0,
+                                              !0,
+                                              'network_error'
+                                          ))();
+                            if (((t = n), !(o < g && !0 === n.retryable)))
+                                throw n;
+                            await d(f(o));
+                        } finally {
+                            (clearTimeout(r), null !== i && clearTimeout(i));
+                        }
+                    }
+                    throw t || new Error('No se pudo completar la solicitud');
+                };
+            if ('GET' !== i || !1 === r.dedupe) return y();
+            if (a.has(l)) return a.get(l);
+            const S = y().finally(() => {
+                a.delete(l);
+            });
+            return (a.set(l, S), S);
+        }
+        function g(e = '', t = '', o = '') {
+            const n = String(e || '').trim(),
+                a = String(t || '').trim(),
+                r = String(o || '').trim();
+            if (n)
+                for (const e of s.keys()) {
+                    if (!e.startsWith(`${n}::`)) continue;
+                    if ('' === a && '' === r) {
+                        s.delete(e);
+                        continue;
+                    }
+                    const t = e.split('::'),
+                        o = t[1] || '',
+                        i = t[2] || '';
+                    ('' === a || o === a) &&
+                        ('' === r || i === r) &&
+                        s.delete(e);
+                }
+            else s.clear();
+        }
+        ((window.Piel = window.Piel || {}),
+            (window.Piel.DataEngine = {
+                init: function (t) {
+                    return (
+                        (e = t || e || {}),
+                        window.Piel && window.Piel.DataEngine
+                    );
+                },
+                apiRequest: m,
+                uploadTransferProof: async function (o, n = {}) {
+                    const a = new FormData();
+                    a.append('proof', o);
+                    const r = new URLSearchParams({
+                            resource: 'transfer-proof',
+                        }),
+                        i = `${t}?${r.toString()}`,
+                        s = Number.isFinite(n.timeoutMs)
+                            ? Math.max(3e3, Number(n.timeoutMs))
+                            : 16e3,
+                        l = Number.isInteger(n.retries)
+                            ? Math.max(0, Number(n.retries))
+                            : 1,
+                        u = new Set([408, 425, 429, 500, 502, 503, 504]);
+                    let p = '';
+                    if (e && 'function' == typeof e.getCaptchaToken)
+                        try {
+                            p = await e.getCaptchaToken('transfer_proof');
+                        } catch (e) {}
+                    let m = null;
+                    for (let e = 0; e <= l; e += 1) {
+                        const t = new AbortController(),
+                            o = setTimeout(() => t.abort(), s);
+                        try {
+                            const e = {};
+                            p && (e['X-Captcha-Token'] = p);
+                            const o = await fetch(i, {
+                                    method: 'POST',
+                                    credentials: 'same-origin',
+                                    headers: e,
+                                    body: a,
+                                    signal: t.signal,
+                                }),
+                                n = await o.text();
+                            let r = {};
+                            try {
+                                r = n ? JSON.parse(n) : {};
+                            } catch (e) {
+                                const t = new Error(
+                                    'No se pudo interpretar la respuesta de subida'
+                                );
+                                throw (
+                                    (t.retryable = u.has(o.status)),
+                                    (t.status = o.status),
+                                    t
+                                );
+                            }
+                            if (!o.ok || !1 === r.ok) {
+                                const e = new Error(
+                                    r.error || `HTTP ${o.status}`
+                                );
+                                throw (
+                                    (e.retryable = u.has(o.status)),
+                                    (e.status = o.status),
+                                    e
+                                );
+                            }
+                            return r.data || {};
+                        } catch (t) {
+                            const o = (() => {
+                                if (t && 'AbortError' === t.name) {
+                                    const e = new Error(
+                                        'es' === c()
+                                            ? 'Tiempo de espera agotado al subir el comprobante'
+                                            : 'Upload timed out while sending proof file'
+                                    );
+                                    return (
+                                        (e.retryable = !0),
+                                        (e.code = 'timeout'),
+                                        e
+                                    );
+                                }
+                                if (w(t)) {
+                                    const e = new Error(
+                                        'es' === c()
+                                            ? 'No se pudo conectar con el servidor al subir el comprobante'
+                                            : 'Could not connect to server while uploading proof'
+                                    );
+                                    return (
+                                        (e.retryable = !0),
+                                        (e.code = 'network_error'),
+                                        e
+                                    );
+                                }
+                                if (t instanceof Error)
+                                    return (
+                                        'boolean' != typeof t.retryable &&
+                                            (t.retryable = !1),
+                                        t
+                                    );
+                                const e = new Error(
+                                    'es' === c()
+                                        ? 'No se pudo subir el comprobante'
+                                        : 'Unable to upload proof'
+                                );
+                                return (
+                                    (e.retryable = !0),
+                                    (e.code = 'upload_error'),
+                                    e
+                                );
+                            })();
+                            if (((m = o), !(e < l && !0 === o.retryable)))
+                                throw o;
+                            await d(f(e));
+                        } finally {
+                            clearTimeout(o);
+                        }
+                    }
+                    throw m || new Error('No se pudo subir el comprobante');
+                },
+                invalidateBookedSlotsCache: g,
+                loadAvailabilityData: async function (e = {}) {
+                    const t = e && !0 === e.forceRefresh,
+                        o = e && !0 === e.background,
+                        n = e && !0 === e.strict,
+                        a = String(e.doctor || 'indiferente'),
+                        s = String(e.service || 'consulta'),
+                        c = String(e.dateFrom || ''),
+                        d = Number.isFinite(Number(e.days))
+                            ? Number(e.days)
+                            : 21,
+                        f = (function (e = {}) {
+                            return `${String(e.doctor || 'indiferente')}::${String(e.service || 'consulta')}::${String(e.dateFrom || '')}::${Number(e.days || 21)}`;
+                        })({ doctor: a, service: s, dateFrom: c, days: d }),
+                        w = Date.now(),
+                        p = r.get(f);
+                    if (!t && p && w - p.at < 6e4) return p.data;
+                    if (!t && i.has(f)) return i.get(f);
+                    const g = `availability:${f}`,
+                        h = (async () => {
+                            try {
+                                const e = { doctor: a, service: s };
+                                (c && (e.dateFrom = c),
+                                    Number.isFinite(d) &&
+                                        d > 0 &&
+                                        (e.days = d));
+                                const t = await m('availability', {
+                                        query: e,
+                                        background: o,
+                                        silentSlowNotice: o,
+                                    }),
+                                    n =
+                                        t && t.data && 'object' == typeof t.data
+                                            ? t.data
+                                            : {};
+                                return (
+                                    r.set(f, {
+                                        data: n,
+                                        at: Date.now(),
+                                        meta:
+                                            t &&
+                                            t.meta &&
+                                            'object' == typeof t.meta
+                                                ? t.meta
+                                                : {},
+                                    }),
+                                    u(g, n),
+                                    n
+                                );
+                            } catch (e) {
+                                if (
+                                    e &&
+                                    ('calendar_unreachable' === e.code ||
+                                        String(e.message || '')
+                                            .toLowerCase()
+                                            .includes('calendar_unreachable'))
+                                )
+                                    throw e;
+                                const t = l(g, {});
+                                if (
+                                    t &&
+                                    'object' == typeof t &&
+                                    Object.keys(t).length > 0
+                                )
+                                    return (
+                                        r.set(f, {
+                                            data: t,
+                                            at: Date.now(),
+                                            meta: { source: 'local_cache' },
+                                        }),
+                                        t
+                                    );
+                                if (n) throw e;
+                                return {};
+                            } finally {
+                                i.delete(f);
+                            }
+                        })();
+                    return (i.set(f, h), h);
+                },
+                getBookedSlots: async function (e, t = '', n = 'consulta') {
+                    const a = (function (e, t = '', o = '') {
+                            return `${String(e || '')}::${String(t || '')}::${String(o || '')}`;
+                        })(e, t, n),
+                        r = Date.now(),
+                        i = s.get(a);
+                    if (i && r - i.at < 1e4) return i.slots;
+                    try {
+                        const o = { date: e };
+                        (t && (o.doctor = t), n && (o.service = n));
+                        const i = await m('booked-slots', { query: o }),
+                            c = Array.isArray(i.data) ? i.data : [];
+                        return (s.set(a, { slots: c, at: r }), c);
+                    } catch (n) {
+                        if (
+                            n &&
+                            ('calendar_unreachable' === n.code ||
+                                String(n.message || '')
+                                    .toLowerCase()
+                                    .includes('calendar_unreachable'))
+                        )
+                            throw n;
+                        if (!o) throw n;
+                        const i = l('appointments', [])
+                                .filter((o) => {
+                                    if (
+                                        o.date !== e ||
+                                        'cancelled' === o.status
+                                    )
+                                        return !1;
+                                    if (t && 'indiferente' !== t) {
+                                        const e = o.doctor || '';
+                                        if (e && 'indiferente' !== e && e !== t)
+                                            return !1;
+                                    }
+                                    return !0;
+                                })
+                                .map((e) => e.time),
+                            c = Array.from(new Set(i));
+                        return (s.set(a, { slots: c, at: r }), c);
+                    }
+                },
+                createAppointmentRecord: async function (e, t = {}) {
+                    const n = !1 !== t.allowLocalFallback;
+                    try {
+                        const t = await m('appointments', {
+                                method: 'POST',
+                                body: e,
+                            }),
+                            o = l('appointments', []);
+                        return (
+                            o.push(t.data),
+                            u('appointments', o),
+                            t && t.data
+                                ? g(
+                                      t.data.date || e?.date || '',
+                                      t.data.doctor || e?.doctor || '',
+                                      t.data.service || e?.service || ''
+                                  )
+                                : g(
+                                      e?.date || '',
+                                      e?.doctor || '',
+                                      e?.service || ''
+                                  ),
+                            {
+                                appointment: t.data,
+                                emailSent: !0 === t.emailSent,
+                            }
+                        );
+                    } catch (t) {
+                        if (!o || !n) throw t;
+                        const a = l('appointments', []),
+                            r = {
+                                ...e,
+                                id: Date.now(),
+                                status: 'confirmed',
+                                dateBooked: new Date().toISOString(),
+                                paymentStatus: e.paymentStatus || 'pending',
+                            };
+                        return (
+                            a.push(r),
+                            u('appointments', a),
+                            g(
+                                r.date || e?.date || '',
+                                r.doctor || e?.doctor || '',
+                                r.service || e?.service || ''
+                            ),
+                            { appointment: r, emailSent: !1 }
+                        );
+                    }
+                },
+                createCallbackRecord: async function (e) {
+                    try {
+                        await m('callbacks', { method: 'POST', body: e });
+                    } catch (t) {
+                        if (!o) throw t;
+                        const n = l('callbacks', []);
+                        (n.push(e), u('callbacks', n));
+                    }
+                },
+                createReviewRecord: async function (e) {
+                    try {
+                        return (await m('reviews', { method: 'POST', body: e }))
+                            .data;
+                    } catch (t) {
+                        if (!o) throw t;
+                        const n = l('reviews', []);
+                        return (n.unshift(e), u('reviews', n), e);
+                    }
+                },
+            }));
+    })();
+    let e = null;
+    const t = new Set(['clinic_hours']),
+        o = { es: null, en: null };
+    let n = null;
+    function a() {
+        e &&
+            'function' == typeof e.debugLog &&
+            e.debugLog.apply(null, arguments);
+    }
+    function r() {
+        return o.en && 'object' == typeof o.en
+            ? Promise.resolve(o.en)
+            : n ||
+                  ((n = fetch('/api.php?resource=content&lang=en')
+                      .then((e) => {
+                          if (!e.ok)
+                              throw new Error('Failed to load EN content');
+                          return e.json();
+                      })
+                      .then((e) => ((o.en = e), o.en))
+                      .catch((e) => {
+                          throw (
+                              (n = null),
+                              a('English translations load failed:', e),
+                              e
+                          );
+                      })),
+                  n);
+    }
+    window.PielI18nEngine = {
+        init: function (t) {
+            return (
+                (e = t || {}),
+                window.PIEL_CONTENT &&
+                    'object' == typeof window.PIEL_CONTENT &&
+                    (o.es = window.PIEL_CONTENT),
+                window.PielI18nEngine
+            );
+        },
+        ensureEnglishTranslations: r,
+        changeLanguage: async function (n) {
+            const i = 'en' === n ? 'en' : 'es';
+            if (
+                ((function (t) {
+                    e &&
+                        'function' == typeof e.setCurrentLang &&
+                        e.setCurrentLang(t);
+                })(i),
+                localStorage.setItem('language', i),
+                (document.documentElement.lang = i),
+                !o.es || 'object' != typeof o.es)
+            )
+                try {
+                    const e = await fetch('/api.php?resource=content&lang=es');
+                    e.ok && (o.es = await e.json());
+                } catch (e) {
+                    a('Failed to load ES content fallback', e);
+                }
+            if ('en' === i && !o.en)
+                try {
+                    await r();
+                } catch (t) {
+                    e &&
+                        'function' == typeof e.showToast &&
+                        e.showToast(
+                            'No se pudo cargar el paquete de idioma EN. Se mantiene Espanol.',
+                            'warning'
+                        );
+                }
+            const s = o[i] || o.es || {};
+            (document.querySelectorAll('.lang-btn').forEach((e) => {
+                e.classList.toggle('active', e.dataset.lang === i);
+            }),
+                document.querySelectorAll('[data-i18n]').forEach((e) => {
+                    const o = String(e.dataset.i18n || '').trim();
+                    Object.prototype.hasOwnProperty.call(s, o) &&
+                        ('INPUT' !== e.tagName && 'TEXTAREA' !== e.tagName
+                            ? t.has(o)
+                                ? (e.innerHTML = s[o])
+                                : (e.textContent = s[o])
+                            : (e.placeholder = s[o]));
+                }));
+            const c =
+                e && 'function' == typeof e.getReviewsCache
+                    ? e.getReviewsCache()
+                    : [];
+            var l;
+            return (
+                Array.isArray(c) &&
+                    c.length > 0 &&
+                    ((l = c),
+                    e &&
+                        'function' == typeof e.renderPublicReviews &&
+                        e.renderPublicReviews(l)),
+                document.dispatchEvent(
+                    new CustomEvent('piel:language-changed', {
+                        detail: { lang: i },
+                    })
+                ),
+                i
+            );
+        },
+    };
+    let i = null,
+        s = !1;
+    function c(e) {
+        if (!i || 'function' != typeof i[e]) return;
+        const t = Array.prototype.slice.call(arguments, 1);
+        return i[e].apply(null, t);
+    }
+    function l(e) {
+        const t = e.target instanceof Element ? e.target : null;
+        if (!t) return;
+        const o = t.closest('[data-action]');
+        if (!o) return;
+        const n = String(o.getAttribute('data-action') || '').trim(),
+            a = o.getAttribute('data-value') || '',
+            r = o.getAttribute('data-booking-service') || '';
+        if (n)
+            switch (n) {
+                case 'toast-close':
+                    o.closest('.toast')?.remove();
+                    break;
+                case 'set-theme':
+                    c('setThemeMode', a || 'system');
+                    break;
+                case 'set-language':
+                    c('changeLanguage', a || 'es');
+                    break;
+                case 'toggle-mobile-menu':
+                    (c('toggleMobileMenu'), r && c('selectService', r));
+                    break;
+                case 'start-web-video':
+                    c('startWebVideo');
+                    break;
+                case 'open-review-modal':
+                    c('openReviewModal');
+                    break;
+                case 'close-review-modal':
+                    c('closeReviewModal');
+                    break;
+                case 'close-video-modal':
+                    c('closeVideoModal');
+                    break;
+                case 'close-payment-modal':
+                    c('closePaymentModal');
+                    break;
+                case 'process-payment':
+                    c('processPayment');
+                    break;
+                case 'close-success-modal':
+                    c('closeSuccessModal');
+                    break;
+                case 'close-reschedule-modal':
+                    c('closeRescheduleModal');
+                    break;
+                case 'submit-reschedule':
+                    c('submitReschedule');
+                    break;
+                case 'toggle-chatbot':
+                    c('toggleChatbot');
+                    break;
+                case 'send-chat-message':
+                    c('sendChatMessage');
+                    break;
+                case 'chat-booking':
+                    c('handleChatBookingSelection', a);
+                    break;
+                case 'quick-message':
+                    c('sendQuickMessage', a);
+                    break;
+                case 'minimize-chat':
+                    c('minimizeChatbot');
+                    break;
+                case 'start-booking':
+                    c('startChatBooking');
+                    break;
+                case 'select-service':
+                    c('selectService', a);
+            }
+    }
+    function u(e) {
+        const t = e.target instanceof Element ? e.target : null;
+        t &&
+            t.closest('[data-action="chat-date-select"]') &&
+            c('handleChatDateSelect', t.value);
+    }
+    ((window.Piel = window.Piel || {}),
+        (window.Piel.ActionRouterEngine = {
+            init: function (e) {
+                return (
+                    (i = e || {}),
+                    s ||
+                        ((s = !0),
+                        document.addEventListener('click', l),
+                        document.addEventListener('change', u)),
+                    window.Piel && window.Piel.ActionRouterEngine
+                        ? window.Piel.ActionRouterEngine
+                        : window.PielActionRouterEngine
+                );
+            },
+        }),
+        (window.PielActionRouterEngine = window.Piel.ActionRouterEngine));
+})();

--- a/src/apps/shared/router.js
+++ b/src/apps/shared/router.js
@@ -38,6 +38,7 @@ function handleActionClick(event) {
 
     const action = String(actionEl.getAttribute('data-action') || '').trim();
     const value = actionEl.getAttribute('data-value') || '';
+    const bookingService = actionEl.getAttribute('data-booking-service') || '';
     if (!action) {
         return;
     }
@@ -54,6 +55,9 @@ function handleActionClick(event) {
             break;
         case 'toggle-mobile-menu':
             callDep('toggleMobileMenu');
+            if (bookingService) {
+                callDep('selectService', bookingService);
+            }
             break;
         case 'start-web-video':
             callDep('startWebVideo');
@@ -130,7 +134,7 @@ function bindListeners() {
 
 window.Piel = window.Piel || {};
 window.Piel.ActionRouterEngine = {
-    init
+    init,
 };
 // Legacy global kept for compatibility with older loaders.
 window.PielActionRouterEngine = window.Piel.ActionRouterEngine;

--- a/telemedicina.html
+++ b/telemedicina.html
@@ -271,7 +271,13 @@
                     </li>
                 </ul>
                 <div class="nav-actions">
-                    <a href="#citas" class="nav-cta" data-i18n="nav_book"
+                    <a
+                        href="#citas"
+                        class="nav-cta"
+                        data-i18n="nav_book"
+                        data-action="select-service"
+                        data-value="video"
+                        data-qa="tele-nav-booking-cta"
                         >Reservar Cita</a
                     >
                 </div>
@@ -333,12 +339,13 @@
             <a
                 href="#citas"
                 data-action="toggle-mobile-menu"
+                data-booking-service="video"
                 class="mobile-cta"
+                data-qa="tele-mobile-booking-cta"
                 data-i18n="nav_book"
                 >Reservar Cita</a
             >
         </div>
-
         <!-- Hero Section -->
         <section class="hero" id="inicio">
             <div class="hero-image-container">
@@ -389,6 +396,9 @@
                         href="#citas"
                         class="btn btn-primary"
                         data-i18n="hero_cta_primary"
+                        data-action="select-service"
+                        data-value="video"
+                        data-qa="tele-hero-booking-cta"
                         >Reservar Consulta</a
                     >
                     <a
@@ -972,7 +982,13 @@
                         navegador.
                     </p>
                     <div class="tele-cta-row">
-                        <a href="#citas" class="btn btn-primary btn-sm">
+                        <a
+                            href="#citas"
+                            class="btn btn-primary btn-sm"
+                            data-action="select-service"
+                            data-value="video"
+                            data-qa="tele-panel-booking-cta"
+                        >
                             <i class="fas fa-calendar-check"></i>
                             <span data-i18n="tele_cta_booking"
                                 >Ver horarios y reservar</span
@@ -1794,6 +1810,7 @@
                                 <option
                                     value="consulta"
                                     data-price="40"
+                                    data-service-tax="0"
                                     data-i18n="opt_consulta"
                                     selected
                                 >
@@ -1802,6 +1819,7 @@
                                 <option
                                     value="telefono"
                                     data-price="25"
+                                    data-service-tax="0"
                                     data-i18n="opt_telefono"
                                 >
                                     Consulta Telefónica - $25
@@ -1809,6 +1827,7 @@
                                 <option
                                     value="video"
                                     data-price="30"
+                                    data-service-tax="0"
                                     data-i18n="opt_video"
                                 >
                                     Video Consulta - $30
@@ -1816,6 +1835,7 @@
                                 <option
                                     value="laser"
                                     data-price="150"
+                                    data-service-tax="0.15"
                                     data-i18n="opt_laser"
                                 >
                                     Tratamiento Láser - desde $150
@@ -1823,9 +1843,26 @@
                                 <option
                                     value="rejuvenecimiento"
                                     data-price="120"
+                                    data-service-tax="0.15"
                                     data-i18n="opt_rejuvenation"
                                 >
                                     Rejuvenecimiento - desde $120
+                                </option>
+                                <option
+                                    value="acne"
+                                    data-price="80"
+                                    data-service-tax="0"
+                                    data-i18n="opt_acne"
+                                >
+                                    Tratamiento de Acne - desde $80
+                                </option>
+                                <option
+                                    value="cancer"
+                                    data-price="70"
+                                    data-service-tax="0"
+                                    data-i18n="opt_cancer"
+                                >
+                                    Deteccion de Cancer - desde $70
                                 </option>
                             </select>
                         </div>
@@ -2110,7 +2147,14 @@
                     <a href="#consultorio" data-i18n="nav_clinic"
                         >Consultorio</a
                     >
-                    <a href="#citas" data-i18n="nav_book">Reservar</a>
+                    <a
+                        href="#citas"
+                        data-i18n="nav_book"
+                        data-action="select-service"
+                        data-value="video"
+                    >
+                        Reservar
+                    </a>
                 </div>
 
                 <div class="footer-legal">
@@ -2171,7 +2215,6 @@
                 </p>
             </div>
         </footer>
-
         <!-- Video Options Modal -->
         <div class="modal" id="videoModal">
             <div class="modal-content">
@@ -2603,7 +2646,13 @@
         </div>
 
         <div class="quick-dock" aria-label="Acciones rapidas">
-            <a href="#citas" class="quick-dock-item">
+            <a
+                href="#citas"
+                class="quick-dock-item"
+                data-action="select-service"
+                data-value="video"
+                data-qa="tele-quickdock-booking-cta"
+            >
                 <i class="fas fa-calendar-check"></i>
                 <span>Reservar</span>
             </a>

--- a/templates/partials/tele-body-footer.html
+++ b/templates/partials/tele-body-footer.html
@@ -23,7 +23,14 @@
                     <a href="#consultorio" data-i18n="nav_clinic"
                         >Consultorio</a
                     >
-                    <a href="#citas" data-i18n="nav_book">Reservar</a>
+                    <a
+                        href="#citas"
+                        data-i18n="nav_book"
+                        data-action="select-service"
+                        data-value="video"
+                    >
+                        Reservar
+                    </a>
                 </div>
 
                 <div class="footer-legal">
@@ -84,4 +91,3 @@
                 </p>
             </div>
         </footer>
-

--- a/templates/partials/tele-body-main.html
+++ b/templates/partials/tele-body-main.html
@@ -48,6 +48,9 @@
                         href="#citas"
                         class="btn btn-primary"
                         data-i18n="hero_cta_primary"
+                        data-action="select-service"
+                        data-value="video"
+                        data-qa="tele-hero-booking-cta"
                         >Reservar Consulta</a
                     >
                     <a
@@ -631,7 +634,13 @@
                         navegador.
                     </p>
                     <div class="tele-cta-row">
-                        <a href="#citas" class="btn btn-primary btn-sm">
+                        <a
+                            href="#citas"
+                            class="btn btn-primary btn-sm"
+                            data-action="select-service"
+                            data-value="video"
+                            data-qa="tele-panel-booking-cta"
+                        >
                             <i class="fas fa-calendar-check"></i>
                             <span data-i18n="tele_cta_booking"
                                 >Ver horarios y reservar</span
@@ -1453,6 +1462,7 @@
                                 <option
                                     value="consulta"
                                     data-price="40"
+                                    data-service-tax="0"
                                     data-i18n="opt_consulta"
                                     selected
                                 >
@@ -1461,6 +1471,7 @@
                                 <option
                                     value="telefono"
                                     data-price="25"
+                                    data-service-tax="0"
                                     data-i18n="opt_telefono"
                                 >
                                     Consulta Telefónica - $25
@@ -1468,6 +1479,7 @@
                                 <option
                                     value="video"
                                     data-price="30"
+                                    data-service-tax="0"
                                     data-i18n="opt_video"
                                 >
                                     Video Consulta - $30
@@ -1475,6 +1487,7 @@
                                 <option
                                     value="laser"
                                     data-price="150"
+                                    data-service-tax="0.15"
                                     data-i18n="opt_laser"
                                 >
                                     Tratamiento Láser - desde $150
@@ -1482,9 +1495,26 @@
                                 <option
                                     value="rejuvenecimiento"
                                     data-price="120"
+                                    data-service-tax="0.15"
                                     data-i18n="opt_rejuvenation"
                                 >
                                     Rejuvenecimiento - desde $120
+                                </option>
+                                <option
+                                    value="acne"
+                                    data-price="80"
+                                    data-service-tax="0"
+                                    data-i18n="opt_acne"
+                                >
+                                    Tratamiento de Acne - desde $80
+                                </option>
+                                <option
+                                    value="cancer"
+                                    data-price="70"
+                                    data-service-tax="0"
+                                    data-i18n="opt_cancer"
+                                >
+                                    Deteccion de Cancer - desde $70
                                 </option>
                             </select>
                         </div>

--- a/templates/partials/tele-body-modals.html
+++ b/templates/partials/tele-body-modals.html
@@ -429,7 +429,13 @@
         </div>
 
         <div class="quick-dock" aria-label="Acciones rapidas">
-            <a href="#citas" class="quick-dock-item">
+            <a
+                href="#citas"
+                class="quick-dock-item"
+                data-action="select-service"
+                data-value="video"
+                data-qa="tele-quickdock-booking-cta"
+            >
                 <i class="fas fa-calendar-check"></i>
                 <span>Reservar</span>
             </a>

--- a/templates/partials/tele-body-nav.html
+++ b/templates/partials/tele-body-nav.html
@@ -102,7 +102,13 @@
                     </li>
                 </ul>
                 <div class="nav-actions">
-                    <a href="#citas" class="nav-cta" data-i18n="nav_book"
+                    <a
+                        href="#citas"
+                        class="nav-cta"
+                        data-i18n="nav_book"
+                        data-action="select-service"
+                        data-value="video"
+                        data-qa="tele-nav-booking-cta"
                         >Reservar Cita</a
                     >
                 </div>
@@ -164,9 +170,10 @@
             <a
                 href="#citas"
                 data-action="toggle-mobile-menu"
+                data-booking-service="video"
                 class="mobile-cta"
+                data-qa="tele-mobile-booking-cta"
                 data-i18n="nav_book"
                 >Reservar Cita</a
             >
         </div>
-

--- a/tests/telemedicina-conversion-qa.spec.js
+++ b/tests/telemedicina-conversion-qa.spec.js
@@ -180,4 +180,87 @@ test.describe('Telemedicina conversion QA', () => {
             `Overflow en #telemedicina (${JSON.stringify(overflowMetrics.offenders)})`
         ).toEqual([]);
     });
+
+    test('CTAs de telemedicina preseleccionan video en el formulario de citas', async ({
+        page,
+    }) => {
+        await page.setViewportSize({ width: 390, height: 844 });
+        await gotoTelemedicina(page);
+
+        await page.evaluate(() =>
+            window.scrollTo({ top: 0, behavior: 'auto' })
+        );
+        const heroBookingCta = page
+            .locator('[data-qa="tele-hero-booking-cta"]')
+            .first();
+        await expect(heroBookingCta).toBeVisible();
+        await heroBookingCta.click({ force: true });
+
+        await expect
+            .poll(
+                async () =>
+                    page.evaluate(() => {
+                        const select = document.getElementById('serviceSelect');
+                        return select ? select.value : null;
+                    }),
+                { timeout: 12000 }
+            )
+            .toBe('video');
+
+        await page.evaluate(() => {
+            const select = document.getElementById('serviceSelect');
+            if (!select) return;
+            select.value = 'consulta';
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+
+        await page.locator('#telemedicina').scrollIntoViewIfNeeded();
+        const panelBookingCta = page
+            .locator('[data-qa="tele-panel-booking-cta"]')
+            .first();
+        await expect(panelBookingCta).toBeVisible();
+        await panelBookingCta.click({ force: true });
+
+        await expect
+            .poll(
+                async () =>
+                    page.evaluate(() => {
+                        const select = document.getElementById('serviceSelect');
+                        return select ? select.value : null;
+                    }),
+                { timeout: 8000 }
+            )
+            .toBe('video');
+
+        await page.evaluate(() => {
+            const select = document.getElementById('serviceSelect');
+            if (!select) return;
+            select.value = 'consulta';
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+
+        await page.evaluate(() =>
+            window.scrollTo({ top: 0, behavior: 'auto' })
+        );
+        await page.locator('.nav-mobile-toggle').click();
+        await expect(page.locator('#mobileMenu')).toHaveClass(/active/);
+
+        const mobileBookingCta = page
+            .locator('[data-qa="tele-mobile-booking-cta"]')
+            .first();
+        await expect(mobileBookingCta).toBeVisible();
+        await mobileBookingCta.click({ force: true });
+
+        await expect(page.locator('#mobileMenu')).not.toHaveClass(/active/);
+        await expect
+            .poll(
+                async () =>
+                    page.evaluate(() => {
+                        const select = document.getElementById('serviceSelect');
+                        return select ? select.value : null;
+                    }),
+                { timeout: 8000 }
+            )
+            .toBe('video');
+    });
 });


### PR DESCRIPTION
## Summary
- enables `data-action="select-service"` + `data-value="video"` across telemedicina booking CTAs (nav, hero, decision panel, footer, quick-dock)
- extends action-router mobile flow: `toggle-mobile-menu` can now carry `data-booking-service` to close menu and prefill booking in one click
- aligns telemedicina booking options with service catalog (`acne`, `cancer`) and tax metadata (`data-service-tax`)
- adds QA coverage for telemedicina CTA preselection (hero, panel, mobile menu)

## Validation
- `npm run build`
- `npx playwright test tests/telemedicina-conversion-qa.spec.js tests/service-pages-qa.spec.js`
