### PR TITLE
fix(ci): point repair git sync to Aurora-Derm repo

### DIFF
--- a/.github/workflows/repair-git-sync.yml
+++ b/.github/workflows/repair-git-sync.yml
@@ -62,7 +62,7 @@ jobs:
             SSH_USERNAME: ${{ secrets.SSH_USERNAME || vars.SSH_USERNAME || secrets.FTP_USERNAME || vars.FTP_USERNAME || '' }}
             SSH_PASSWORD: ${{ secrets.SSH_PASSWORD || vars.SSH_PASSWORD || secrets.FTP_PASSWORD || vars.FTP_PASSWORD || '' }}
             SSH_REPO_DIR: ${{ github.event.inputs.repo_dir || vars.SSH_REPO_DIR || '/var/www/figo' }}
-            REPO_GIT_URL: https://github.com/erosero558558/piel-en-armonia.git
+            REPO_GIT_URL: https://github.com/erosero558558/Aurora-Derm.git
             PUBLIC_SYNC_HOST_WRAPPER_PATH: /root/sync-pielarmonia.sh
             PUBLIC_SYNC_REPO_WRAPPER_RELATIVE_PATH: bin/deploy-public-v3-cron-sync.sh
             HOST_CRON_WRAPPER_SYNC_STATE: not_evaluated


### PR DESCRIPTION
## Summary
- fix epair-git-sync to target the live Aurora-Derm repository instead of the legacy piel-en-armonia repo
- keep the change minimal so we can retry official hosting repair without mixing extra deploy logic

## Validation
- parsed .github/workflows/repair-git-sync.yml
- confirmed no remaining rosero558558/piel-en-armonia.git references under .github/workflows

## Context
- production merge for PR #444 is already on main, but official hosting remains blocked and the current repair workflow points at the wrong repo URL
