### PR TITLE
Fix diagnose turnero status exit capture

### DIFF
--- a/.github/workflows/diagnose-host-connectivity.yml
+++ b/.github/workflows/diagnose-host-connectivity.yml
@@ -223,9 +223,10 @@ jobs:
                   status_path="turnero-pilot-diagnose.json"
                   raw_path="turnero-pilot-diagnose.raw.txt"
                   status_exit=0
-                  if ! node bin/turnero-clinic-profile.js status --json > "${status_path}" 2>"${raw_path}"; then
-                    status_exit=$?
-                  fi
+                  set +e
+                  node bin/turnero-clinic-profile.js status --json > "${status_path}" 2>"${raw_path}"
+                  status_exit=$?
+                  set -e
                   export TURNERO_PILOT_DIAGNOSE_STATUS_EXIT="${status_exit}"
                   export TURNERO_PILOT_DIAGNOSE_STATUS_PATH="${status_path}"
                   export TURNERO_PILOT_DIAGNOSE_STATUS_RAW_PATH="${raw_path}"

--- a/tests-node/deploy-hosting-workflow-contract.test.js
+++ b/tests-node/deploy-hosting-workflow-contract.test.js
@@ -1142,6 +1142,12 @@ test('diagnose-host-connectivity publica reporte estructurado y gestiona inciden
         "TURNERO_PILOT_EXPECTED_CLINIC_ID: ${{ github.event.inputs.turnero_clinic_id || '' }}",
         "TURNERO_PILOT_EXPECTED_PROFILE_FINGERPRINT: ${{ github.event.inputs.turnero_profile_fingerprint || '' }}",
         "TURNERO_PILOT_EXPECTED_RELEASE_MODE: ${{ github.event.inputs.turnero_release_mode || '' }}",
+        'set +e',
+        'status_path="turnero-pilot-diagnose.json"',
+        'raw_path="turnero-pilot-diagnose.raw.txt"',
+        'node bin/turnero-clinic-profile.js status --json > "${status_path}" 2>"${raw_path}"',
+        'status_exit=$?',
+        'set -e',
         'node bin/turnero-clinic-profile.js status --json',
         "const reportPath = 'connectivity-report.json';",
         'report.turneroPilot = {',
@@ -1202,5 +1208,12 @@ test('diagnose-host-connectivity publica reporte estructurado y gestiona inciden
         raw.includes('uses: actions/github-script@v7'),
         false,
         'diagnose-host-connectivity ya no debe depender de actions/github-script@v7'
+    );
+    assert.equal(
+        raw.includes(
+            'if ! node bin/turnero-clinic-profile.js status --json > "${status_path}" 2>"${raw_path}"; then'
+        ),
+        false,
+        'diagnose-host-connectivity no debe invertir el exit code del status local de turneroPilot'
     );
 });


### PR DESCRIPTION
## Summary
- preserve the real exit code from 	urnero-clinic-profile status --json in diagnose-host-connectivity
- avoid the false profile_status_unreadable:SyntaxError path caused by if ! ...; then status_exit=True
- lock the safer pattern with the workflow contract test

## Validation
- 
ode --test tests-node/deploy-hosting-workflow-contract.test.js

## Context
This does not unblock production transport by itself. It makes the connectivity incident truthful so the next diagnose run distinguishes a failing CLI from malformed JSON output.