### PR TITLE
Checkout repo in diagnose connectivity workflow

### DIFF
--- a/.github/workflows/diagnose-host-connectivity.yml
+++ b/.github/workflows/diagnose-host-connectivity.yml
@@ -52,6 +52,11 @@ jobs:
             TURNERO_PILOT_DIAGNOSE_EXPECTED_REASON: not_evaluated
             TURNERO_PILOT_DIAGNOSE_RECOVERY_TARGETS: none
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+
             - name: Diagnosticar puertos por origen de host
               shell: bash
               run: |

--- a/tests-node/deploy-hosting-workflow-contract.test.js
+++ b/tests-node/deploy-hosting-workflow-contract.test.js
@@ -1110,6 +1110,7 @@ test('diagnose-host-connectivity publica reporte estructurado y gestiona inciden
     );
 
     for (const expectedStepName of [
+        'Checkout repository',
         'Diagnosticar puertos por origen de host',
         'Consolidar reporte de conectividad',
         'Resolver turneroPilot local para diagnose',
@@ -1129,6 +1130,8 @@ test('diagnose-host-connectivity publica reporte estructurado y gestiona inciden
         'connectivity-report.json',
         'connectivity-report.txt',
         'connectivity-report.tsv',
+        'uses: actions/checkout@v4',
+        'fetch-depth: 1',
         'GITHUB_TOKEN: ${{ github.token }}',
         "const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';",
         'authorization: `Bearer ${token}`',


### PR DESCRIPTION
## Summary
- add ctions/checkout@v4 to diagnose-host-connectivity
- allow the workflow to actually run in/turnero-clinic-profile.js on GitHub-hosted runners
- protect the checkout requirement in the workflow contract test

## Validation
- 
ode --test tests-node/deploy-hosting-workflow-contract.test.js

## Context
The previous hotfix fixed the false exit-code inversion. This one fixes the missing workspace so the diagnose workflow can report the real turneroPilot profile state instead of failing before it loads the repo.